### PR TITLE
feature/expanded-autonaming

### DIFF
--- a/src/main/scala/org.rogach.scallop/ScallopConf.scala
+++ b/src/main/scala/org.rogach.scallop/ScallopConf.scala
@@ -162,7 +162,7 @@ abstract class ScallopConf(val args: Seq[String] = Nil, protected val commandnam
   }
 
   def propsLong[A](
-      name: String,
+      name: String = "Props",
       descr: String = "",
       keyName: String = "key",
       valueName: String = "value",

--- a/src/main/scala/org.rogach.scallop/ScallopConf.scala
+++ b/src/main/scala/org.rogach.scallop/ScallopConf.scala
@@ -147,7 +147,7 @@ abstract class ScallopConf(val args: Seq[String] = Nil, protected val commandnam
     * @return A holder for retreival of the values.
     */
   def props[A](
-      name: Char,
+      name: Char = 'D',
       descr: String = "",
       keyName: String = "key",
       valueName: String = "value",

--- a/src/test/scala/DefaultNames.scala
+++ b/src/test/scala/DefaultNames.scala
@@ -1,0 +1,18 @@
+package org.rogach.scallop
+
+import org.scalatest.FunSuite
+import org.scalatest.matchers.ShouldMatchers
+import org.rogach.scallop._
+import org.rogach.scallop.exceptions._
+
+class DefaultNames extends UsefulMatchers with CapturingTest with ShouldMatchers {
+
+  test("default for props") {
+    object Conf extends ScallopConf(List("-D", "foo=bar,", "bar=baz,", "baz=bippy")) {
+      val properties = props[String]()
+      verify()
+    }
+    Conf.properties should equal (Map("foo"->"bar", "bar"->"baz", "baz"->"bippy"))
+  }
+
+}

--- a/src/test/scala/DefaultNames.scala
+++ b/src/test/scala/DefaultNames.scala
@@ -15,4 +15,11 @@ class DefaultNames extends UsefulMatchers with CapturingTest with ShouldMatchers
     Conf.properties should equal (Map("foo"->"bar", "bar"->"baz", "baz"->"bippy"))
   }
 
+  test("default name for propsLong") {
+    object Conf extends ScallopConf(List("--Props", "foo=bar", "bar=baz")) {
+      val properties = propsLong[String]()
+    }
+    Conf.properties should equal (Map("foo" -> "bar", "bar" -> "baz"))
+  }
+
 }

--- a/src/test/scala/OptionNameGuessing.scala
+++ b/src/test/scala/OptionNameGuessing.scala
@@ -70,4 +70,20 @@ class OptionNameGuessing extends UsefulMatchers {
     Conf.trailing2.get should be (Some(List("foo", "bar", "baz", "bippy")))
   }
 
+  test("toggle name guessing") {
+    object Conf extends ScallopConf(List("--foo", "--nobippy", "-s")) {
+      val foo = toggle()
+      val zoop = toggle()
+      val bippy = toggle()
+      val scooby = toggle()
+    }
+    Conf.foo.name should be ("foo")
+    Conf.zoop.name should be ("zoop")
+    Conf.bippy.name should be ("bippy")
+    Conf.foo.get should be (Some(true))
+    Conf.zoop.get should be (None)
+    Conf.bippy.get should be (Some(false))
+    Conf.scooby.get should be (Some(true))
+  }
+
 }

--- a/src/test/scala/OptionNameGuessing.scala
+++ b/src/test/scala/OptionNameGuessing.scala
@@ -58,4 +58,16 @@ class OptionNameGuessing extends UsefulMatchers {
     Conf.xs.get ==== Some("1")
   }
 
+  test("trailArg name guessing") {
+    object Conf extends ScallopConf(List("1", "foo", "bar", "baz", "bippy")) {
+      val trailing1 = trailArg[Int]()
+      val trailing2 = trailArg[List[String]]()
+      verify()
+    }
+    Conf.trailing1.name should be ("trailing1")
+    Conf.trailing2.name should be ("trailing2")
+    Conf.trailing1.get should be (Some(1))
+    Conf.trailing2.get should be (Some(List("foo", "bar", "baz", "bippy")))
+  }
+
 }


### PR DESCRIPTION
This pull request contains patches to allow Scallop to supply intelligent default names for all option types:
- Guess the names of toggles using the same method as is currently used for opts
- Guess the names of trailArgs using the same method as is currently used for opts
- Use a default name of "D" for props
- Use a default name of "Props" for propsLongs

These changes should slightly reduce the number of keystrokes needed in order to get started with Scallop, as it mostly eliminates the need to type the names for your options twice.
