### PR TITLE
Build cleanup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ scalacOptions ++= Seq(
   "-Ywarn-all"
 )
 
-seq(Revolver.settings: _*)
+Revolver.settings
 
 resolvers += "Scala Tools Snapshots" at "http://scala-tools.org/repo-snapshots/"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-import AssemblyKeys._
 
 organization := "org.rogach"
 
@@ -19,8 +18,6 @@ scalacOptions ++= Seq(
 )
 
 seq(Revolver.settings: _*)
-
-seq(assemblySettings: _*)
 
 resolvers += "Scala Tools Snapshots" at "http://scala-tools.org/repo-snapshots/"
 

--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,20 @@ publishTo <<= version { v: String =>
     Some("releases" at nexus + "service/local/staging/deploy/maven2")
 }
 
+licenses := Seq(
+  "MIT License" -> url("http://www.opensource.org/licenses/mit-license.php")
+)
+
+homepage := Some(url("https://github.com/Rogach/scallop"))
+
+scmInfo := Some(
+  ScmInfo(
+    browseUrl = url("http://github.com/Rogach/scallop"),
+    connection = "scm:git:git@github.com:Rogach/scallop.git"
+  )
+)
+
+
 publishMavenStyle := true
 
 publishArtifact in Test := false
@@ -46,17 +60,6 @@ publishArtifact in Test := false
 pomIncludeRepository := { x => false }
 
 pomExtra := (
-  <url>https://github.com/Rogach/scallop</url>
-  <licenses>
-    <license>
-      <name>MIT License</name>
-      <url>http://www.opensource.org/licenses/mit-license.php</url>
-    </license>
-  </licenses>
-  <scm>
-    <url>git@github.com:Rogach/scallop.git</url>
-    <connection>scm:git:git@github.com:Rogach/scallop.git</connection>
-  </scm>
   <developers>
     <developer>
       <id>rogach</id>

--- a/checklist.txt
+++ b/checklist.txt
@@ -4,9 +4,9 @@ Release
 * Write notes for herald. (optional)
 * +compile
 * +test
-* +publish
+* +publish-signed
 * Commit the changes.
-* switch branch to for-2.9, merge master, compile, test, publish
+* switch branch to for-2.9, merge master, compile, test, publish-signed
 * Tag the release (on master).
 * Close the release in Nexus UI.
 * Push latest version to github. (push --all; push --tags)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,6 +1,7 @@
 import sbt._
 import Keys._
 import fmpp.FmppPlugin._
+import com.typesafe.sbt.pgp.PgpKeys._
 import org.eclipse.jgit.lib._
 
 object build extends Build {
@@ -35,7 +36,7 @@ object build extends Build {
 
     val snapshotIndex = {
       import dispatch._
-      Http(url("https://oss.sonatype.org/content/repositories/snapshots/org/rogach/scallop_2.9.2/") OK as.tagsoup.NodeSeq).map { x =>
+      Http(url("https://oss.sonatype.org/content/repositories/snapshots/org/rogach/scallop_2.10/") OK as.tagsoup.NodeSeq).map { x =>
         val vRgx = (""".*%s~(\d+)~SNAPSHOT.*""" format eVersion).r
         x \\ "a" map (_.text) collect { case vRgx(v) => v.toInt}
       }.apply.sorted.lastOption.map(1+).getOrElse(1)
@@ -46,7 +47,7 @@ object build extends Build {
 
     crossVersions.foreach { scalaVers =>
       Project.runTask(
-        publish in Compile,
+        publishSigned in Compile,
         extracted.append(List(version := snapshotVersion, scalaVersion := scalaVers), state),
         true)
     }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,25 +1,28 @@
 import sbt._
 import Keys._
 import fmpp.FmppPlugin._
+import org.eclipse.jgit.lib._
 
 object build extends Build {
   
   val versRgx = """[0-9]+\.[0-9]+\.[0-9]+""".r
   val readmeVersion = versRgx.findFirstIn(io.Source.fromFile("README.md").getLines.toList.filter(_.contains("libraryDependencies")).mkString).get
-  
-  val branch = {
-    import sys.process._
-    "git status" #| Seq("grep", "On branch") #| Seq("sed", "s_\\#\\s*On\\s*branch\\s*__") lines
-  }.head.trim
+
+  val builder = new RepositoryBuilder()
+  builder.setGitDir(file(".git"))
+  val repo = builder.readEnvironment().findGitDir().build()
+
+  val branch = repo.getBranch
+
   println("git branch: %s" format branch)
+
+  val vers = if (branch == "master" || branch == "for-2.9")
+    readmeVersion
+  else {
+    val n = readmeVersion.split("\\.")
+    (n.init :+ (n.last.toInt + 1)).mkString(".") + "-SNAPSHOT"
+  }
   
-  val vers = 
-    if (branch == "master" || branch == "for-2.9")
-      readmeVersion
-    else {
-      val n = readmeVersion.split("\\.")
-      (n.init :+ (n.last.toInt + 1)).mkString(".") + "-SNAPSHOT"
-    }
   println("version: %s" format vers)
   
   def publishSnapshot = Command.command("publish-snapshot") { state =>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,10 +9,9 @@ libraryDependencies ++= Seq(
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.6.2")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.8.4")
-
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.7")
 
 addSbtPlugin("com.github.sbt" %% "sbt-fmpp" % "0.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.0")
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ libraryDependencies ++= Seq(
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.6.2")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.7")
+addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8")
 
 addSbtPlugin("com.github.sbt" %% "sbt-fmpp" % "0.3")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,8 @@
-resolvers ++= Seq(
-  "jgit-repo" at "http://download.eclipse.org/jgit/maven"
-)
 
 libraryDependencies ++= Seq(
   "net.databinder.dispatch" %% "dispatch-core" % "0.9.5",
-  "net.databinder.dispatch" %% "dispatch-tagsoup" % "0.9.5"
+  "net.databinder.dispatch" %% "dispatch-tagsoup" % "0.9.5",
+  "org.eclipse.jgit" % "org.eclipse.jgit" % "2.3.1.201302201838-r"
 )
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.6.2")


### PR DESCRIPTION
This is a set of commits that clean up the sbt build a bit.

The biggest advantage is that, with this changeset, the
build won't fail when you aren't on a git branch.

Note that this changeset moves to using jgit to determine
the current branch, since calling out to the shell is not a
cross-platform solution (e.g. sed works differently on
OS X than it does on Linux and is unlikely to exist on
Windows).

Also note that it updates sbt-pgp to 0.8, which does
not publish signed artifacts by default (you have to run
publish-signed).
