### PR TITLE
Update jgit version and force correct jgit.pgm

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,8 @@
 libraryDependencies ++= Seq(
   "net.databinder.dispatch" %% "dispatch-core" % "0.9.5",
   "net.databinder.dispatch" %% "dispatch-tagsoup" % "0.9.5",
-  "org.eclipse.jgit" % "org.eclipse.jgit" % "2.3.1.201302201838-r"
+	"org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "3.0.0.201306101825-r",
+  "org.eclipse.jgit" % "org.eclipse.jgit" % "3.0.0.201306101825-r"
 )
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8")


### PR DESCRIPTION
These changes will update to the latest published version of jgit and fix issues where sbt would tries to
pull in the wrong version of git.pgm (the practical effect of which is to render sbt unable to start up on a
system that doesn't already have jgit and jgit.pgm cached).
