### PR TITLE
Suppress "trailing arguments" from output if all trailing args are hidden

### DIFF
--- a/src/main/scala/org.rogach.scallop/Scallop.scala
+++ b/src/main/scala/org.rogach.scallop/Scallop.scala
@@ -529,12 +529,13 @@ case class Scallop(
       }.mkString("\n")
       if (subHelp.nonEmpty) "\n\n" + subHelp else subHelp
     }
+    val trailOpts = opts filter (_.isPositional) filter (!_.hidden)
     val trailHelp = Formatter format (
-      opts filter (_.isPositional) filter (!_.hidden) flatMap (_.helpInfo(Nil)) map (Some(_)),
+      trailOpts flatMap (_.helpInfo(Nil)) map (Some(_)),
       helpWidth,
       needToAppendDefaultToDescription
     )
-    val formattedHelp = if (opts filter (_.isPositional) isEmpty) {
+    val formattedHelp = if (trailOpts isEmpty) {
       optsHelp + subcommandsHelp
     } else {
       optsHelp + "\n\n trailing arguments:\n" + trailHelp + subcommandsHelp

--- a/src/test/scala/HelpTest.scala
+++ b/src/test/scala/HelpTest.scala
@@ -28,6 +28,7 @@ class HelpTest extends UsefulMatchers with CapturingTest {
 
           val palm = new Subcommand("palm") {
             val leaves = opt[Int]("leaves", descr = "how many leaves?")
+            val hiddenTrail = trailArg[String]("secret", descr = "secret trailing arg", hidden = true)
           }
           addSubcommand(palm)
 


### PR DESCRIPTION
Without this change, a hidden `trailArg` will produce an empty `trailing arguments:` footer.
