### PR TITLE
Avoid Throwable; use Exception

### DIFF
--- a/src/main/scala/org.rogach.scallop/Exceptions.scala
+++ b/src/main/scala/org.rogach.scallop/Exceptions.scala
@@ -6,9 +6,9 @@ import reflect.runtime.universe._
 sealed trait ScallopResult
 
 /** Thrown when user requested help output (via "--help") */
-case class Help(command: String) extends Throwable with ScallopResult
+case class Help(command: String) extends Exception with ScallopResult
 /** Thrown when user requested version printout (via "--version") */
-case object Version extends Throwable with ScallopResult
+case object Version extends Exception with ScallopResult
 /** Extractor object, for matching on both Help and Version results. */
 object Exit {
   def unapply(r: ScallopResult) = r match {

--- a/src/main/scala/org.rogach.scallop/ScallopConf.scala
+++ b/src/main/scala/org.rogach.scallop/ScallopConf.scala
@@ -351,7 +351,7 @@ abstract class ScallopConf(val args: Seq[String] = Nil, protected val commandnam
       builder.verify
       runValidations()
     } catch {
-      case e: Throwable =>
+      case e: Exception =>
         onError(e)
     }
   }

--- a/src/main/scala/org.rogach.scallop/package.scala
+++ b/src/main/scala/org.rogach.scallop/package.scala
@@ -19,7 +19,7 @@ package object scallop {
     def parse(s: List[(String, List[String])]) = {
       s match {
         case (_, i :: Nil) :: Nil =>
-          try { Right(Some(conv(i))) } catch { case _: Throwable => Left("wrong arguments format") }
+          try { Right(Some(conv(i))) } catch { case _: Exception => Left("wrong arguments format") }
         case Nil => Right(None)
         case _ => Left("you should provide exactly one argument for this option")
       }
@@ -49,7 +49,7 @@ package object scallop {
         val l = s.map(_._2).flatten.map(i => conv(i))
         if (l.isEmpty) Right(None)
         else Right(Some(l))
-      } catch { case _: Throwable =>
+      } catch { case _: Exception =>
         Left("wrong arguments format")
       }
     }
@@ -75,7 +75,7 @@ package object scallop {
           if (m.nonEmpty) Some(m)
           else None
         }
-      } catch { case _: Throwable =>
+      } catch { case _: Exception =>
         Left("wrong arguments format")
       }
     }


### PR DESCRIPTION
This is generally considered bad practice, since it can catch `Error` as well as `Exception`; see [this stackoverflow answer](http://stackoverflow.com/a/581935/2581396) for a good summary of when you'd want to do this.
