### PR TITLE
Add more helpful error messages for single-argument types.

### DIFF
--- a/src/test/scala/ConfTest.scala
+++ b/src/test/scala/ConfTest.scala
@@ -597,7 +597,7 @@ For all other tricks, consult the documentation!
   }
 
   test ("verification on subconfigs") {
-    expectException(WrongOptionFormat("apples", "b", "wrong arguments format")) {
+    expectException(WrongOptionFormat("apples", "b", "bad Int value")) {
       val conf = new ScallopConf(Seq("tree", "-a", "b")) {
         val tree = new Subcommand("tree") {
           val apples = opt[Int]()

--- a/src/test/scala/ErrorsTest.scala
+++ b/src/test/scala/ErrorsTest.scala
@@ -75,7 +75,7 @@ class ErrorsTest extends FunSuite with Matchers with UsefulMatchers {
   }
 
   test ("option verification failure") {
-    expectException(WrongOptionFormat("ang", "1.2", "wrong arguments format")) {
+    expectException(WrongOptionFormat("ang", "1.2", "bad Int value")) {
       val opts = Scallop(List("-a","1.2", "-b"))
         .opt[Int]("ang")
         .opt[Boolean]("bang")

--- a/src/test/scala/Usability.scala
+++ b/src/test/scala/Usability.scala
@@ -6,7 +6,7 @@ class Usability extends UsefulMatchers {
   throwError.value = true
 
   test ("printing error message for single argument") {
-    expectException(WrongOptionFormat("apples", "asdf", "wrong arguments format")) {
+    expectException(WrongOptionFormat("apples", "asdf", "bad Int value")) {
       new ScallopConf(Seq("-a","asdf")) {
         val apples = opt[Int]("apples")
         val bananas = opt[Int]("bananas")


### PR DESCRIPTION
It's really hard to figure out what you've done wrong if you type a bad number when Scallop expects one.

I also added helpful messages for URL / URI.
