### PR TITLE
Fix nested subcommand validation.

### DIFF
--- a/src/main/scala/org.rogach.scallop/Scallop.scala
+++ b/src/main/scala/org.rogach.scallop/Scallop.scala
@@ -450,6 +450,9 @@ case class Scallop(
     subbuilders.find(_._1 == sn).map(_._2)
   }
 
+  /** Returns the subcommand arguments. */
+  def getSubcommandArgs: List[String] = parsed.subcommandArgs
+
   /** Returns the list of subcommand names, recursively. */
   def getSubcommandNames: List[String] = {
     parsed.subcommand.map(subName => subbuilders.find(_._1 == subName).map(s => s._1 :: s._2.args(parsed.subcommandArgs).getSubcommandNames).getOrElse(Nil)).getOrElse(Nil)

--- a/src/main/scala/org.rogach.scallop/ScallopConf.scala
+++ b/src/main/scala/org.rogach.scallop/ScallopConf.scala
@@ -370,6 +370,7 @@ abstract class ScallopConf(val args: Seq[String] = Nil, protected val commandnam
       subBuilder <- builder.getSubbuilder
       subConfig <- subconfigs.find(_.builder == subBuilder)
     } {
+      subConfig.editBuilder(_.args(builder.getSubcommandArgs))
       subConfig.runValidations
     }
   }

--- a/src/test/scala/ConfTest.scala
+++ b/src/test/scala/ConfTest.scala
@@ -627,6 +627,27 @@ For all other tricks, consult the documentation!
     }
   }
 
+  test ("validation failure on nested subconfigs") {
+    expectException(ValidationFailure("branch: a + b must be < 3")) {
+      val conf = new ScallopConf(Seq("tree", "branch", "-a", "1", "-b", "5")) {
+        val tree = new Subcommand("tree") {
+          val branch = new Subcommand("branch") {
+            val apples = opt[Int]()
+            val bananas = opt[Int]()
+            validate(apples, bananas) { (a, b) =>
+              if (a + b >= 3) Left("branch: a + b must be < 3")
+              else Right(Unit)
+            }
+          }
+          addSubcommand(branch)
+        }
+        addSubcommand(tree)
+
+        verify()
+      }
+    }
+  }
+
   test ("validationOpt failure on subconfigs") {
     expectException(ValidationFailure("both a and b must be supplied")) {
       val conf = new ScallopConf(Seq("tree", "-a", "1")) {


### PR DESCRIPTION
Any `validate` registrations are currently skipped on nested subcommands. This fixes that.

Note that there isn't a way to do this without constructing a `ScallopConf` for the nested subcommand which has the parsed arguments in its `Scallop` builder. I did this the most direct way, by editing the builder - you should let me know if you have other ideas or would prefer a copy were made instead.
