### PR TITLE
added filtered summary getter

### DIFF
--- a/src/main/scala/org.rogach.scallop/Scallop.scala
+++ b/src/main/scala/org.rogach.scallop/Scallop.scala
@@ -715,12 +715,23 @@ case class Scallop(
     * Returns a list of all options in the builder, and corresponding values for them.
     */
   def summary: String = {
-    ("Scallop(%s)" format args.mkString(", ")) + "\n" +
-    opts.map(o =>
-      " %s  %s => %s" format ((if (isSupplied(o.name)) "*" else " "),
-                              o.name,
-                              get(o.name)(o.converter.tag).getOrElse("<None>"))
-    ).mkString("\n") + "\n" + parsed.subcommand.map { sn =>
+    ("Scallop(%s)" format args.mkString(", ")) + "\n" + filteredSummary(Set.empty)
+  }
+
+  /** Get summary of current parser state + blurring the values of parameters provided.
+    *
+    * @param blurred names of arguments that should be hidden.
+    *
+    * Returns a list of all options in the builder, and corresponding values for them
+    * with eventually blurred values.
+    */
+  def filteredSummary(blurred:Set[String]): String = {
+    lazy val hide = "************"
+    opts.map { o =>
+      " %s  %s => %s" format((if (isSupplied(o.name)) "*" else " "),
+        o.name,
+        if(!blurred.contains(o.name)) get(o.name)(o.converter.tag).getOrElse("<None>") else hide)
+    }.mkString("\n") + "\n" + parsed.subcommand.map { sn =>
       ("subcommand: %s\n" format sn) + subbuilders.find(_._1 == sn).get._2.args(parsed.subcommandArgs).summary
     }.getOrElse("")
   }

--- a/src/main/scala/org.rogach.scallop/ScallopConf.scala
+++ b/src/main/scala/org.rogach.scallop/ScallopConf.scala
@@ -582,6 +582,11 @@ abstract class ScallopConf(
     builder.summary
   }
 
+  def filteredSummary(blurred: Set[String]) = {
+    assertVerified
+    builder.filteredSummary(blurred: Set[String])
+  }
+
   /** Prints help message (with version, banner, option usage and footer) to stdout. */
   def printHelp() = builder.printHelp
 


### PR DESCRIPTION
Hi, 

the motivation behind is, that is often useful to print the summary of the configuration during the start/debug process. However, printing sensitive information like credentials could be a security issue. Filtered summary would get the summary but replace the values of sensitive information with `********`.