### PR TITLE
Scallop#hashCode can be painfully slow; rewrite to avoid

### DIFF
--- a/src/main/scala/org.rogach.scallop/Scallop.scala
+++ b/src/main/scala/org.rogach.scallop/Scallop.scala
@@ -527,11 +527,16 @@ case class Scallop(
         "\n\nSubcommands:\n" + subbuilders.map(s => "  " + s._1.padTo(maxCommandLength, ' ') + "   " + s._2.descr).mkString("\n")
       }.getOrElse("")
     } else {
-      val subHelp = subbuilders
-        .groupBy(_._2)
-        .mapValues(_.map(_._1))
-        .toList
-        .sortBy { case (subBuilder, names) => subbuilders.indexWhere(_._2 == subBuilder) }
+      val subHelp =
+        subbuilders.foldLeft(Seq.empty[(Scallop, Seq[String])]) {
+          case (acc, (name, subBuilder)) =>
+            acc.indexWhere(_._1 == subBuilder) match {
+              case -1 => acc :+ (subBuilder -> Seq(name))
+              case i  =>
+                val (currentSubBuilder, currentNames) = acc(i)
+                acc.updated(i, (currentSubBuilder, currentNames :+ name))
+            }
+        }
         .map { case (sub, names) =>
           val subName =
             if (names.size == 1) names.head


### PR DESCRIPTION
We have a CLI with a couple dozen subcommands (only one generation deep) that takes over six minutes to print `--help`, and the problem is that `hashCode` on `Scallop` can be incredibly slow—on the order of seconds for our subcommands.

To be honest off the top of my head I don't know why it doesn't spin forever, given the cycles in the case class (but I'm not curious enough to dig any deeper). The change in this PR just makes sure that we don't put `Scallop` values into a map when printing the help message. The behavior should be identical—it's just using `equals` instead of `hashCode`.

With this change our `--help` drops from ~375 seconds to ~7.

/cc @johnynek