### PR TITLE
Fix path to test suite in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This snippet above defined simple configuration that will parse argument lines l
 -a 4 appleTree
 ```
 
-For more examples, you can look at Scallop's [wiki](https://github.com/scallop/scallop/wiki) and [test suite](./src/test/scala).
+For more examples, you can look at Scallop's [wiki](https://github.com/scallop/scallop/wiki) and [test suite](./jvm/src/test/scala).
 
 Fancy things
 ============


### PR DESCRIPTION
For now it redirects to 404, which may be quite annoying for someone who just started with scallop and often navigates to test suite from the README link.