### PR TITLE
Check `short` argument for Toggle Options

### DIFF
--- a/jvm/src/test/scala/ToggleOptionTest.scala
+++ b/jvm/src/test/scala/ToggleOptionTest.scala
@@ -1,0 +1,29 @@
+package org.rogach.scallop
+
+import org.scalatest.{FunSuite, Matchers}
+import org.rogach.scallop._
+import org.rogach.scallop.exceptions._
+
+
+class ToggleOptionTest extends FunSuite with Matchers {
+  throwError.value = true
+
+  test ("short name") {
+    val conf = new ScallopConf(Seq("-e")) {
+      val answer = toggle(name = "tgl-option", short = 'e', default = Some(false))
+      verify()
+    }
+    conf.answer() shouldBe true
+  }
+
+  test("unknown option") {
+    assertThrows[UnknownOption] {
+      val conf = new ScallopConf(Seq("-t")) {
+        val answer = toggle(name = "tgl-option", short = 'e', default = Some(false))
+        verify()
+      }
+    }
+  }
+
+
+}

--- a/src/main/scala/org.rogach.scallop/CliOptions.scala
+++ b/src/main/scala/org.rogach.scallop/CliOptions.scala
@@ -191,7 +191,7 @@ case class ToggleOption(
   def converter = new ValueConverter[Boolean] {
     def parse(s: List[(String, List[String])]) = {
       val noname = prefix + name
-      val shortname = name.head.toString
+      val shortname = short.getOrElse(name.head).toString
       s match {
         case (`name`, Nil) :: Nil => Right(Some(true))
         case (`noname`, Nil) :: Nil => Right(Some(false))


### PR DESCRIPTION
If `short` argument is provided for the Toggle Option, then that should
take precedence over the first character of the `name` argument.

Fixes #158