### PR TITLE
add support for Scala 2.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ scala:
   - 2.10.7
   - 2.11.12
   - 2.12.8
-  - 2.13.0-RC3
+  - 2.13.0
 jdk:
   - oraclejdk8
 before_script:

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val commonSettings = Seq(
     versionRegexp.findFirstIn(libraryDependenciesString).get
   },
   scalaVersion := "2.12.8",
-  crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.8", "2.13.0-RC3"),
+  crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.8", "2.13.0"),
   scalacOptions ++= Seq(
     "-deprecation",
     "-unchecked",
@@ -86,9 +86,13 @@ lazy val scallop =
   .enablePlugins(SiteScaladocPlugin, GhpagesPlugin)
   .configure(_.enablePlugins(spray.boilerplate.BoilerplatePlugin))
   .jvmSettings(
-    libraryDependencies ++= Seq(
-      "org.scalatest" %%% "scalatest" % "3.0.8-RC5" % Test
-    ),
+    libraryDependencies += {
+      val v = "3.0.8-RC5"
+      if (scalaVersion.value == "2.13.0")
+        "org.scalatest" % "scalatest_2.13.0-RC3" % v % Test
+      else
+        "org.scalatest" %%% "scalatest" % v % Test
+    },
     // fix for paths to source files in scaladoc
     doc in Compile := {
       import sys.process._

--- a/js/src/main/scala/org.rogach.scallop/ScallopArgListLoader.scala
+++ b/js/src/main/scala/org.rogach.scallop/ScallopArgListLoader.scala
@@ -1,5 +1,7 @@
 package org.rogach.scallop
 
+import scala.collection.{Seq => CSeq}
+
 trait ScallopArgListLoader {
-  def loadArgList(args: Seq[String]): Seq[String] = args
+  def loadArgList(args: CSeq[String]): CSeq[String] = args
 }

--- a/jvm/src/main/scala/org.rogach.scallop/ScallopArgListLoader.scala
+++ b/jvm/src/main/scala/org.rogach.scallop/ScallopArgListLoader.scala
@@ -1,7 +1,9 @@
 package org.rogach.scallop
 
+import scala.collection.{Seq => CSeq}
+
 trait ScallopArgListLoader {
-  def loadArgList(args: Seq[String]): Seq[String] =
+  def loadArgList(args: CSeq[String]): CSeq[String] =
     if (args.headOption map("@--" ==) getOrElse false) {
       // read options from stdin
       io.Source.fromInputStream(java.lang.System.in).getLines.toList

--- a/native/src/main/scala/org.rogach.scallop/ScallopArgListLoader.scala
+++ b/native/src/main/scala/org.rogach.scallop/ScallopArgListLoader.scala
@@ -1,7 +1,9 @@
 package org.rogach.scallop
 
+import scala.collection.{Seq => CSeq}
+
 trait ScallopArgListLoader {
-  def loadArgList(args: Seq[String]): Seq[String] =
+  def loadArgList(args: CSeq[String]): CSeq[String] =
     if (args.headOption map("@--" ==) getOrElse false) {
       // read options from stdin
       io.Source.fromInputStream(java.lang.System.in).getLines.toList

--- a/src/main/scala/org.rogach.scallop/Scallop.scala
+++ b/src/main/scala/org.rogach.scallop/Scallop.scala
@@ -2,6 +2,8 @@ package org.rogach.scallop
 
 import org.rogach.scallop.exceptions._
 
+import scala.collection.{Seq => CSeq}
+
 /** The creator and god of all parsers :) */
 private[scallop] object Scallop {
 
@@ -9,7 +11,7 @@ private[scallop] object Scallop {
     *
     * @param args Args to pre-insert.
     */
-  def apply(args: Seq[String]): Scallop = new Scallop(args)
+  def apply(args: CSeq[String]): Scallop = new Scallop(args)
 
   /** Create the default empty parser, fresh as mountain air. */
   def apply(): Scallop = apply(Nil)
@@ -57,7 +59,7 @@ private[scallop] object Scallop {
   * @param subbuilders subcommands in this builder
   */
 case class Scallop(
-  args: Seq[String] = Nil,
+  args: CSeq[String] = Nil,
   opts: List[CliOption] = Nil,
   mainOpts: List[String] = Nil,
   vers: Option[String] = None,
@@ -82,7 +84,7 @@ case class Scallop(
   )
 
   /** Parse the argument into list of options and their arguments. */
-  private def parse(args: Seq[String]): ParseResult = {
+  private def parse(args: CSeq[String]): ParseResult = {
     subbuilders.filter(s => args.contains(s._1)).sortBy(s => args.indexOf(s._1)).headOption match {
       case Some((name, sub)) => ParseResult(parse(Nil, args.takeWhile(name!=).toList), Some(name), args.dropWhile(name!=).drop(1).toList)
       case None => ParseResult(parse(Nil, args.toList))

--- a/src/main/scala/org.rogach.scallop/ScallopConfBase.scala
+++ b/src/main/scala/org.rogach.scallop/ScallopConfBase.scala
@@ -1,8 +1,11 @@
 package org.rogach.scallop
 
 import java.io.File
-import java.nio.file.{Path, Files}
-import exceptions._
+import java.nio.file.{Files, Path}
+
+import org.rogach.scallop.exceptions._
+
+import scala.collection.{Seq => CSeq}
 
 class Subcommand(commandNameAndAliases: String*) extends ScallopConf(Nil, commandNameAndAliases) {
   /** Short description for this subcommand. Used if parent command has shortSubcommandsHelp enabled. */
@@ -12,7 +15,7 @@ class Subcommand(commandNameAndAliases: String*) extends ScallopConf(Nil, comman
 }
 
 abstract class ScallopConfBase(
-  val args: Seq[String] = Nil,
+  val args: CSeq[String] = Nil,
   protected val commandNameAndAliases: Seq[String] = Nil
 ) extends ScallopConfValidations {
 


### PR DESCRIPTION
- change versions from 2.13.0-RC3 to 2.13.0
- use ScalaTest 2.13.0-RC3 while new version is not yet published
  (tests succeed, this is not an issue)
- in Scala 2.13, `scala.Seq` means `scala.collection.immutable.Seq`,
  unlike Scala 2.11 and 2.12, where the alias points to
  `sala.collection.Seq`. In general, we want to keep `scala.Seq`
  because immutable is better, however for Scallop, command line
  options typically come from `def main(args: Array[String])`, and
  here Scala will start to unnecessarily convert the array to an
  immutable seq in Scala 2.13, also giving a compiler warning.
  The solution proposed here is to explicitly use `s.c.Seq` so
  that an `Array[String]` can still be used without defense copying.
  Note that import `s.c.{Seq => CSeq}` has no consequence for Scala
  2.11 and 2.12 (and thus scala native and scala js), because the
  type is still the same. See also
  https://github.com/scopt/scopt/issues/218