### PR TITLE
Add Duration converters

### DIFF
--- a/jvm/src/test/scala/DefaultConverterTest.scala
+++ b/jvm/src/test/scala/DefaultConverterTest.scala
@@ -1,0 +1,47 @@
+package org.rogach.scallop
+
+import org.rogach.scallop.exceptions._
+
+import org.scalatest.FunSuite
+
+import scala.concurrent.duration._
+
+class DurationConverterTest extends FunSuite with UsefulMatchers {
+  throwError.value = true
+
+  test("convert to Duration") {
+    def getcf(args: Seq[String]) = new ScallopConf(args) {
+      val foo = opt[Duration]()
+      verify()
+    }
+
+    getcf(List("-f", "1 minute")).foo.toOption ==== Some(1.minute)
+    getcf(List("-f", "Inf")).foo.toOption ==== Some(Duration.Inf)
+    getcf(List("-f", "MinusInf")).foo.toOption ==== Some(Duration.MinusInf)
+
+    expectException(WrongOptionFormat("foo", "bar", "wrong arguments format")) {
+      getcf(List("-f", "bar")).foo.toOption ==== Some(Duration.MinusInf)
+    }
+  }
+}
+
+class FiniteDurationConverterTest extends FunSuite with UsefulMatchers {
+  throwError.value = true
+
+  test("convert to Duration") {
+    def getcf(args: Seq[String]) = new ScallopConf(args) {
+      val foo = opt[FiniteDuration]()
+      verify()
+    }
+
+    getcf(List("-f", "1 minute")).foo.toOption ==== Some(1.minute)
+
+    expectException(WrongOptionFormat("foo", "Inf", "wrong arguments format")) {
+      getcf(List("-f", "Inf")).foo.toOption ==== Some(Duration.Inf)
+    }
+
+    expectException(WrongOptionFormat("foo", "bar", "wrong arguments format")) {
+      getcf(List("-f", "bar")).foo.toOption ==== Some(Duration.MinusInf)
+    }
+  }
+}

--- a/src/main/scala/org.rogach.scallop/DefaultConverters.scala
+++ b/src/main/scala/org.rogach.scallop/DefaultConverters.scala
@@ -3,6 +3,7 @@ package org.rogach.scallop
 import org.rogach.scallop.exceptions.GenericScallopException
 
 import scala.util.Try
+import scala.concurrent.duration.{Duration, FiniteDuration}
 
 trait DefaultConverters {
   implicit val flagConverter = new ValueConverter[Boolean] {
@@ -64,6 +65,14 @@ trait DefaultConverters {
     singleArgConverter(BigInt(_), numberHandler("integer"))
   implicit val bigDecimalConverter: ValueConverter[BigDecimal] =
     singleArgConverter(BigDecimal(_), numberHandler("decimal"))
+  implicit val durationConverter: ValueConverter[Duration] =
+    singleArgConverter(Duration(_))
+  implicit val finiteDurationConverter = singleArgConverter[FiniteDuration] { arg =>
+    Duration(arg) match {
+      case d: FiniteDuration => d
+      case d => throw new IllegalArgumentException(s"'$d' is not a FiniteDuration.")
+    }
+  }
 
   def listArgConverter[A](conv: String => A) = new ValueConverter[List[A]] {
     def parse(s:List[(String, List[String])]) = {


### PR DESCRIPTION
Allows easy Duration and FiniteDuration parsing, like:

--foo="1 minute"
-s 10s

Fixes https://github.com/scallop/scallop/issues/199