### PR TITLE
Make the default value for the noshort parameter configurable

### DIFF
--- a/jvm/src/test/scala/NoshortDefaultValueTest.scala
+++ b/jvm/src/test/scala/NoshortDefaultValueTest.scala
@@ -1,0 +1,37 @@
+package org.rogach.scallop
+
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
+
+class NoshortDefaultValueTest extends UsefulMatchers with CapturingTest with Matchers with Inspectors {
+
+  test("noshort default value") {
+
+    case class NoshortConf(initialNoshort: Boolean, reassignedNoshort: Boolean) extends ScallopConf(List("-a", "x", "-b", "x", "-c", "-d")) {
+      _noshort shouldBe false // check whether hard-coded default in ScallopConfBase is false
+      noshort(initialNoshort) // for all subsequent options, set global default for noshort to initialNoshort
+      val a1 = opt[String]()
+      val a2 = opt[String](noshort = false)
+      val b1 = choice(choices = Seq("x"))
+      val b2 = choice(choices = Seq("x"), noshort = false)
+      noshort(reassignedNoshort) // for all subsequent options, set global default for noshort to reassignedNoshort
+      val c1 = tally()
+      val c2 = tally(noshort = false)
+      val d1 = toggle()
+      val d2 = toggle(noshort = false)
+      verify()
+    }
+
+    forAll(List((false, false), (false, true), (true, false), (true, true))) { case (initialNoshort, reassignedNoshort) => {
+      val conf = NoshortConf(initialNoshort, reassignedNoshort)
+      conf.a1.isSupplied shouldBe !initialNoshort
+      conf.a2.isSupplied shouldBe initialNoshort
+      conf.b1.isSupplied shouldBe !initialNoshort
+      conf.b2.isSupplied shouldBe initialNoshort
+      conf.c1.isSupplied shouldBe !reassignedNoshort
+      conf.c2.isSupplied shouldBe reassignedNoshort
+      conf.d1.isSupplied shouldBe !reassignedNoshort
+      conf.d2.isSupplied shouldBe reassignedNoshort
+    }}
+  }
+}

--- a/jvm/src/test/scala/NoshortDefaultValueTest.scala
+++ b/jvm/src/test/scala/NoshortDefaultValueTest.scala
@@ -8,13 +8,13 @@ class NoshortDefaultValueTest extends UsefulMatchers with CapturingTest with Mat
   test("noshort default value") {
 
     case class NoshortConf(initialNoshort: Boolean, reassignedNoshort: Boolean) extends ScallopConf(List("-a", "x", "-b", "x", "-c", "-d")) {
-      _noshort shouldBe false // check whether hard-coded default in ScallopConfBase is false
-      noshort(initialNoshort) // for all subsequent options, set global default for noshort to initialNoshort
+      noshort shouldBe false // check whether hard-coded default in ScallopConfBase is false
+      noshort = initialNoshort // for all subsequent options, set global default for noshort to initialNoshort
       val a1 = opt[String]()
       val a2 = opt[String](noshort = false)
       val b1 = choice(choices = Seq("x"))
       val b2 = choice(choices = Seq("x"), noshort = false)
-      noshort(reassignedNoshort) // for all subsequent options, set global default for noshort to reassignedNoshort
+      noshort = reassignedNoshort // for all subsequent options, set global default for noshort to reassignedNoshort
       val c1 = tally()
       val c2 = tally(noshort = false)
       val d1 = toggle()

--- a/src/main/scala/org.rogach.scallop/ScallopConfBase.scala
+++ b/src/main/scala/org.rogach.scallop/ScallopConfBase.scala
@@ -25,6 +25,9 @@ abstract class ScallopConfBase(
   /** true if this config does not represent a subcommand */
   protected var isRootConfig = true
 
+  /** Default value for the noshort parameter, may be overridden, or re-defined by noshort(Boolean). */
+  protected var _noshort = false
+
   private def rootConfig: ScallopConfBase = {
     var conf = this
     while (!conf.isRootConfig) {
@@ -133,7 +136,7 @@ abstract class ScallopConfBase(
       required: Boolean = false,
       argName: String = "arg",
       hidden: Boolean = false,
-      noshort: Boolean = false)
+      noshort: Boolean = _noshort)
       (implicit conv:ValueConverter[A]): ScallopOption[A] = {
 
     // guessing name, if needed
@@ -180,7 +183,7 @@ abstract class ScallopConfBase(
     required: Boolean = false,
     argName: String = "arg",
     hidden: Boolean = false,
-    noshort: Boolean = false
+    noshort: Boolean = _noshort
   ): ScallopOption[String] = {
     this.opt[String](
       name = name,
@@ -224,7 +227,7 @@ abstract class ScallopConfBase(
       short: Char = '\u0000',
       descr: String = "",
       hidden: Boolean = false,
-      noshort: Boolean = false): ScallopOption[Int] = {
+      noshort: Boolean = _noshort): ScallopOption[Int] = {
 
     // guessing name, if needed
     val resolvedName =
@@ -375,7 +378,7 @@ abstract class ScallopConfBase(
       name: String = null,
       default: => Option[Boolean] = None,
       short: Char = '\u0000',
-      noshort: Boolean = false,
+      noshort: Boolean = _noshort,
       prefix: String = "no",
       descrYes: String = "",
       descrNo: String = "",
@@ -803,6 +806,14 @@ abstract class ScallopConfBase(
     */
   def helpWidth(w: Int): Unit = {
     editBuilder(_.setHelpWidth(w))
+  }
+
+  /** Sets the default value for the noshort-parameter for all subsequent option definitions in this ScallopConf.
+    * Only applied if an option definition does not explicitly provide its noshort-parameter.
+    * @param noshort new default value
+    */
+  def noshort(noshort: Boolean): Unit = {
+    _noshort = noshort
   }
 
   def shortSubcommandsHelp(v: Boolean = true): Unit = {

--- a/src/main/scala/org.rogach.scallop/ScallopConfBase.scala
+++ b/src/main/scala/org.rogach.scallop/ScallopConfBase.scala
@@ -25,9 +25,6 @@ abstract class ScallopConfBase(
   /** true if this config does not represent a subcommand */
   protected var isRootConfig = true
 
-  /** Default value for the noshort parameter, may be overridden, or re-defined by noshort(Boolean). */
-  protected var _noshort = false
-
   private def rootConfig: ScallopConfBase = {
     var conf = this
     while (!conf.isRootConfig) {
@@ -77,6 +74,12 @@ abstract class ScallopConfBase(
   def helpFormatter_=(formatter: ScallopHelpFormatter) = {
     editBuilder(_.copy(helpFormatter = formatter))
   }
+
+  /** Default value for the noshort-parameter for all subsequent option definitions in this ScallopConf.
+    * May be overridden or re-assigned.
+    * Only applied if a subsequent option definition does not explicitly provide its noshort-parameter.
+    */
+  protected var noshort = false
 
   private[this] var gen = 0
   private[this] def genName() = { gen += 1; Util.format("\t%d", gen) }
@@ -136,7 +139,7 @@ abstract class ScallopConfBase(
       required: Boolean = false,
       argName: String = "arg",
       hidden: Boolean = false,
-      noshort: Boolean = _noshort)
+      noshort: Boolean = noshort)
       (implicit conv:ValueConverter[A]): ScallopOption[A] = {
 
     // guessing name, if needed
@@ -183,7 +186,7 @@ abstract class ScallopConfBase(
     required: Boolean = false,
     argName: String = "arg",
     hidden: Boolean = false,
-    noshort: Boolean = _noshort
+    noshort: Boolean = noshort
   ): ScallopOption[String] = {
     this.opt[String](
       name = name,
@@ -227,7 +230,7 @@ abstract class ScallopConfBase(
       short: Char = '\u0000',
       descr: String = "",
       hidden: Boolean = false,
-      noshort: Boolean = _noshort): ScallopOption[Int] = {
+      noshort: Boolean = noshort): ScallopOption[Int] = {
 
     // guessing name, if needed
     val resolvedName =
@@ -375,14 +378,14 @@ abstract class ScallopConfBase(
     * @param hidden If set to true, then this option will not be present in auto-generated help.
     */
   def toggle(
-      name: String = null,
-      default: => Option[Boolean] = None,
-      short: Char = '\u0000',
-      noshort: Boolean = _noshort,
-      prefix: String = "no",
-      descrYes: String = "",
-      descrNo: String = "",
-      hidden: Boolean = false): ScallopOption[Boolean] = {
+              name: String = null,
+              default: => Option[Boolean] = None,
+              short: Char = '\u0000',
+              noshort: Boolean = noshort,
+              prefix: String = "no",
+              descrYes: String = "",
+              descrNo: String = "",
+              hidden: Boolean = false): ScallopOption[Boolean] = {
     val resolvedName =
       if (name == null) {
         if (_guessOptionName) genName()
@@ -806,14 +809,6 @@ abstract class ScallopConfBase(
     */
   def helpWidth(w: Int): Unit = {
     editBuilder(_.setHelpWidth(w))
-  }
-
-  /** Sets the default value for the noshort-parameter for all subsequent option definitions in this ScallopConf.
-    * Only applied if an option definition does not explicitly provide its noshort-parameter.
-    * @param noshort new default value
-    */
-  def noshort(noshort: Boolean): Unit = {
-    _noshort = noshort
   }
 
   def shortSubcommandsHelp(v: Boolean = true): Unit = {


### PR DESCRIPTION
As requested by https://github.com/scallop/scallop/issues/198, this PR adds the functionality to set a default value for the noshort parameter that applies to all subsequent option definitions.