### PR TITLE
Provide a default noshort value for the Scallop builder, too

### DIFF
--- a/jvm/src/test/scala/NoshortDefaultValueTest.scala
+++ b/jvm/src/test/scala/NoshortDefaultValueTest.scala
@@ -5,10 +5,9 @@ import org.scalatest.matchers.should.Matchers
 
 class NoshortDefaultValueTest extends UsefulMatchers with CapturingTest with Matchers with Inspectors {
 
-  test("noshort default value") {
+  test("noshort default value via ScallopConf") {
 
     case class NoshortConf(initialNoshort: Boolean, reassignedNoshort: Boolean) extends ScallopConf(List("-a", "x", "-b", "x", "-c", "-d")) {
-      noshort shouldBe false // check whether hard-coded default in ScallopConfBase is false
       noshort = initialNoshort // for all subsequent options, set global default for noshort to initialNoshort
       val a1 = opt[String]()
       val a2 = opt[String](noshort = false)
@@ -32,6 +31,22 @@ class NoshortDefaultValueTest extends UsefulMatchers with CapturingTest with Mat
       conf.c2.isSupplied shouldBe reassignedNoshort
       conf.d1.isSupplied shouldBe !reassignedNoshort
       conf.d2.isSupplied shouldBe reassignedNoshort
+    }}
+  }
+
+  test("noshort default value via Scallop") {
+    forAll(List(false, true)) { noshort => {
+      val conf = Scallop(Seq("-a", "x", "-b"), noshort = noshort)
+        .opt[String]("a1")
+        .opt[String]("a2", noshort = false)
+        .toggle("b1")
+        .toggle("b2", noshort = false)
+        .verify
+
+      conf.isSupplied("a1") shouldBe !noshort
+      conf.isSupplied("a2") shouldBe noshort
+      conf.isSupplied("b1") shouldBe !noshort
+      conf.isSupplied("b2") shouldBe noshort
     }}
   }
 }

--- a/src/main/scala/org.rogach.scallop/Scallop.scala
+++ b/src/main/scala/org.rogach.scallop/Scallop.scala
@@ -56,6 +56,9 @@ private[scallop] object Scallop {
   * @param descr Short description - used for subcommands
   * @param helpWidth Width, to which the help output will be formatted (note that banner, footer, version and description are not affected!)
   * @param shortSubcommandsHelp If true, then help output from this builder wouldn't list full help for subcommands, only short description
+  * @param appendDefaultToDescription If true, then append auto-generated text about default option value to option descriptions
+  * @param noshort If true, then do not generate short names for options by default unless overridden per option by providing its noshort parameter
+  * @param helpFormatter help formatter in this builder
   * @param subbuilders subcommands in this builder
   */
 case class Scallop(
@@ -69,6 +72,7 @@ case class Scallop(
   helpWidth: Option[Int] = None,
   shortSubcommandsHelp: Boolean = false,
   appendDefaultToDescription: Boolean = false,
+  noshort: Boolean = false,
   helpFormatter: ScallopHelpFormatter = new ScallopHelpFormatter,
   subbuilders: List[(String, Scallop)] = Nil
 ) extends ScallopArgListLoader {
@@ -268,7 +272,7 @@ case class Scallop(
       required: Boolean = false,
       argName: String = "arg",
       hidden: Boolean = false,
-      noshort: Boolean = false)
+      noshort: Boolean = noshort)
       (implicit conv: ValueConverter[A]): Scallop = {
     if (name.head.isDigit) throw new IllegalOptionParameters(Util.format("First character of the option name must not be a digit: %s", name))
     val defaultA =
@@ -401,7 +405,7 @@ case class Scallop(
       name: String,
       default: () => Option[Boolean] = () => None,
       short: Char = '\u0000',
-      noshort: Boolean = false,
+      noshort: Boolean = noshort,
       prefix: String = "no",
       descrYes: String = "",
       descrNo: String = "",

--- a/src/main/scala/org.rogach.scallop/ScallopConfBase.scala
+++ b/src/main/scala/org.rogach.scallop/ScallopConfBase.scala
@@ -75,11 +75,14 @@ abstract class ScallopConfBase(
     editBuilder(_.copy(helpFormatter = formatter))
   }
 
-  /** Default value for the noshort-parameter for all subsequent option definitions in this ScallopConf.
-    * May be overridden or re-assigned.
+  def noshort = builder.noshort
+
+  /** If set to true, then do not generate short names for subsequently defined options by default.
     * Only applied if a subsequent option definition does not explicitly provide its noshort-parameter.
     */
-  protected var noshort = false
+  def noshort_=(v: Boolean): Unit = {
+    editBuilder(_.copy(noshort = v))
+  }
 
   private[this] var gen = 0
   private[this] def genName() = { gen += 1; Util.format("\t%d", gen) }


### PR DESCRIPTION
As a follow-up of PR #206, this PR moves the location where the default value for the `noshort` flag is stored from `ScallopBaseConf.noshort` to `Scallop.noshort`, and applies all required modifications and additional tests.
Now, the `noshort` functionality is not only available when creating configurations via inheriting from `ScallopConf`, but also when using the `Scallop` builder directly.