### PR TITLE
Add path list converter

### DIFF
--- a/jvm/src/main/scala/org.rogach.scallop/package.scala
+++ b/jvm/src/main/scala/org.rogach.scallop/package.scala
@@ -12,6 +12,8 @@ package object scallop extends DefaultConverters {
   implicit val pathConverter = singleArgConverter[Path](Paths.get(_), {
     case e: InvalidPathException => Left("bad Path, %s" format e.getMessage)
   })
+  implicit val pathListConverter: ValueConverter[List[Path]] =
+    listArgConverter[Path](Paths.get(_))
   implicit val urlConverter = singleArgConverter(new URL(_), {
     case e: MalformedURLException => Left("bad URL, %s" format e.getMessage)
   })


### PR DESCRIPTION
Scallop currently has a built-in `ValueConverter[Path]` but not a `ValueConverter[List[Path]]`. This PR adds the latter.