### PR TITLE
support Dotty 3.0.0-M2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 .idea/
+.bsp/

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ jdk:
   - openjdk8
 
 script:
-  - sbt "++${TRAVIS_SCALA_VERSION}" scallopJVM/test scallopJS/test scallopNative/test
+  - sbt "++${TRAVIS_SCALA_VERSION}" scallopJVM/test scallopJS/test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
+dist: xenial
+
 language: scala
+
 scala:
-  - 2.10.7
   - 2.11.12
-  - 2.12.8
-  - 2.13.0
+  - 2.12.12
+  - 2.13.4
+  - 3.0.0-M2
+
 jdk:
   - openjdk8
-before_script:
-  - sudo chmod +x /usr/local/bin/sbt
+
 script:
-  - sbt "++${TRAVIS_SCALA_VERSION}!" scallopJVM/test
+  - sbt "++${TRAVIS_SCALA_VERSION}" scallopJVM/test scallopJS/test scallopNative/test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 Scallop
 ========
-A simple command-line arguments parsing library for Scala, written in spirit of Ruby's [Trollop](http://manageiq.github.io/trollop/). Cross-built for Scala 2.10, 2.11, 2.12, 2.13, Dotty, supports Scala Native and Scala JS.
+
+[![Build Status](https://api.travis-ci.org/scallop/scallop.svg?branch=develop)](https://travis-ci.org/scallop/scallop)
+
+A simple command-line arguments parsing library for Scala, written in spirit of Ruby's [Trollop](http://manageiq.github.io/trollop/).
+Cross-built for Scala 2.11, 2.12, 2.13, Dotty, supports Scala Native and Scala JS.
 
 Scallop supports:
 

--- a/build.sbt
+++ b/build.sbt
@@ -67,7 +67,10 @@ lazy val commonSettings = Seq(
   },
   publishMavenStyle := true,
   publishArtifact in Test := false,
-  scalacOptions in (Compile, doc) ++= Opts.doc.sourceUrl("https://github.com/scallop/scallop/blob/develop/€{FILE_PATH}.scala"),
+  scalacOptions in (Compile, doc) ++= {
+    if (isDotty.value) Nil
+    else Opts.doc.sourceUrl("https://github.com/scallop/scallop/blob/develop/€{FILE_PATH}.scala")
+  },
   parallelExecution in Test := false,
   siteSubdirName in SiteScaladoc := "",
   git.remoteRepo := "git@github.com:scallop/scallop.git"
@@ -117,9 +120,4 @@ lazy val scallop =
     libraryDependencies ++= Seq(
       "org.scalatest" %%% "scalatest" % scalaTestVersion % Test
     ),
-    // there is a strange bug "java.lang.IllegalArgumentException: malformed version: 0.6.17"
-    // when trying to test under Scala 2.12
-    Test / test := {
-      if (scalaVersion.value.startsWith("2.12")) () else (Test / test).value
-    },
   )

--- a/js/src/test/scala/JSTests.scala
+++ b/js/src/test/scala/JSTests.scala
@@ -6,12 +6,12 @@ import org.scalatest.matchers.should.Matchers
 class JSTests extends AnyFunSuite with Matchers {
 
   test("small example") {
-    val conf = new ScallopConf(List("-a","3")) {
+    object Conf extends ScallopConf(List("-a","3")) {
       val apples = opt[Int]("apples")
       verify()
     }
-    conf.apples() shouldBe 3
-    conf.builder.help shouldBe """  -a, --apples  <arg>
+    Conf.apples() shouldBe 3
+    Conf.builder.help shouldBe """  -a, --apples  <arg>
                                  |  -h, --help            Show help message""".stripMargin
   }
 

--- a/jvm/src/main/scala/org.rogach.scallop/package.scala
+++ b/jvm/src/main/scala/org.rogach.scallop/package.scala
@@ -6,7 +6,7 @@ import java.nio.file.{InvalidPathException,Path,Paths}
 
 package object scallop extends DefaultConverters {
   implicit val fileConverter: ValueConverter[File] =
-    singleArgConverter(new File(_))
+    singleArgConverter(new File(_), PartialFunction.empty)  // Note: important to provide default arg (Dotty)
   implicit val fileListConverter: ValueConverter[List[File]] =
     listArgConverter(new File(_))
   implicit val pathConverter: ValueConverter[Path] = singleArgConverter[Path](Paths.get(_), {

--- a/jvm/src/test/scala-2.13/LegacyScallopTest.scala
+++ b/jvm/src/test/scala-2.13/LegacyScallopTest.scala
@@ -2,7 +2,6 @@ package org.rogach.scallop
 
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import org.rogach.scallop._
 import org.rogach.scallop.exceptions._
 import reflect.runtime.universe._
 
@@ -55,7 +54,7 @@ class LegacyScallopTest extends AnyFunSuite with Matchers with CapturingTest {
     opts("pet name") should equal ("Pigeon")
 
     val (helpOut, helpErr) = captureOutput {
-      opts.printHelp
+      opts.printHelp()
     }
     helpOut shouldBe """test 1.2.3 (c) 2012 Mr Placeholder
 Usage: test [OPTION]... [pet-name]

--- a/jvm/src/test/scala/ConfTest.scala
+++ b/jvm/src/test/scala/ConfTest.scala
@@ -5,6 +5,12 @@ import org.scalatest.matchers.should.Matchers
 import org.rogach.scallop._
 import org.rogach.scallop.exceptions._
 
+/*
+  to test only this suite:
+
+  sbt 'testOnly org.rogach.scallop.ConfTest'
+
+ */
 class ConfTest extends AnyFunSuite with Matchers with UsefulMatchers with CapturingTest {
   throwError.value = true
 
@@ -60,7 +66,7 @@ class ConfTest extends AnyFunSuite with Matchers with UsefulMatchers with Captur
       verify()
     }
     val (out, err) = captureOutput {
-      Conf.builder.printHelp
+      Conf.builder.printHelp()
     }
 
     out shouldBe """test 1.2.3 (c) 2012 Mr Placeholder
@@ -531,60 +537,60 @@ For all other tricks, consult the documentation!
   }
 
   test ("default value of option should be lazily evaluated") {
-    val conf = new ScallopConf(Seq("-a", "4")) {
+    object Conf extends ScallopConf(Seq("-a", "4")) {
       val apples = opt[Int](default = { sys.error("boom"); None })
       verify()
     }
-    conf.apples() should equal (4)
+    Conf.apples() should equal (4)
   }
 
   test ("default value of trailing arg should be lazily evaluated") {
-    val conf = new ScallopConf(Seq("4")) {
+    object Conf extends ScallopConf(Seq("4")) {
       val apples = trailArg[Int](default = { sys.error("boom"); None })
       verify()
     }
-    conf.apples() should equal (4)
+    Conf.apples() should equal (4)
   }
 
   test ("if no arguments provided for list option, default should be returned") {
-    val conf = new ScallopConf(Seq()) {
+    object Conf extends ScallopConf(Seq()) {
       val apples = opt[List[Int]](default = Some(List(1)))
       verify()
     }
-    conf.apples() should equal (List(1))
+    Conf.apples() should equal (List(1))
   }
 
   test ("empty tally") {
-    val conf = new ScallopConf(Seq()) {
+    object Conf extends ScallopConf(Seq()) {
       val apples = tally()
       verify()
     }
-    conf.apples() should equal (0)
-    conf.apples.isSupplied should equal (false)
+    Conf.apples() should equal (0)
+    Conf.apples.isSupplied should equal (false)
   }
 
   test ("one-arg tally") {
-    val conf = new ScallopConf(Seq("-a")) {
+    object Conf extends ScallopConf(Seq("-a")) {
       val apples = tally()
       verify()
     }
-    conf.apples() should equal (1)
+    Conf.apples() should equal (1)
   }
 
   test ("two-arg tally") {
-    val conf = new ScallopConf(Seq("-a", "-a")) {
+    object Conf extends ScallopConf(Seq("-a", "-a")) {
       val apples = tally()
       verify()
     }
-    conf.apples() should equal (2)
+    Conf.apples() should equal (2)
   }
 
   test ("collapsed two-arg tally") {
-    val conf = new ScallopConf(Seq("-aa")) {
+    object Conf extends ScallopConf(Seq("-aa")) {
       val apples = tally()
       verify()
     }
-    conf.apples() should equal (2)
+    Conf.apples() should equal (2)
   }
 
   test ("tally no-args") {
@@ -598,29 +604,29 @@ For all other tricks, consult the documentation!
   }
 
   test ("empty list arg before empty trailing option") {
-    val conf = new ScallopConf(Seq("-a")) {
+    object Conf extends ScallopConf(Seq("-a")) {
       val apples = opt[List[String]](default = Some(Nil))
       verify()
     }
-    conf.apples() ==== List()
+    Conf.apples() ==== List()
   }
 
   test ("multiple list option before normal option should keep ordering") {
-    val conf = new ScallopConf(Seq("-l", "1", "-l", "2", "-o", "3")) {
+    object Conf extends ScallopConf(Seq("-l", "1", "-l", "2", "-o", "3")) {
       val l = opt[List[String]]()
       val o = opt[Int]()
       verify()
     }
-    conf.l() ==== List("1","2")
+    Conf.l() ==== List("1","2")
   }
 
   test ("multiple list option before optional trail arg should keep ordering") {
-    val conf = new ScallopConf(Seq("-l", "1", "-l", "2", "--", "0")) {
+    object Conf extends ScallopConf(Seq("-l", "1", "-l", "2", "--", "0")) {
       val l = opt[List[String]]()
       val t = trailArg[Int](required = false)
       verify()
     }
-    conf.l() ==== List("1","2")
+    Conf.l() ==== List("1","2")
   }
 
   test ("verification on subconfigs") {
@@ -720,41 +726,41 @@ For all other tricks, consult the documentation!
   }
 
   test ("--arg=value option style") {
-    val conf = new ScallopConf(Seq("--apples=42")) {
+    object Conf extends ScallopConf(Seq("--apples=42")) {
       val apples = opt[Int]()
       verify()
     }
 
-    conf.apples() shouldBe 42
+    Conf.apples() shouldBe 42
   }
 
   test ("pass arguments that start with dash") {
-    val conf = new ScallopConf(Seq("--apples=-1")) {
+    object Conf extends ScallopConf(Seq("--apples=-1")) {
       val apples = opt[Int]()
       verify()
     }
 
-    conf.apples() shouldBe (-1)
+    Conf.apples() shouldBe (-1)
   }
 
   test ("pass list of arguments in --arg=value option style") {
-    val conf = new ScallopConf(Seq("--apples=-1", "--apples=-2")) {
+    object Conf extends ScallopConf(Seq("--apples=-1", "--apples=-2")) {
       val apples = opt[List[Int]]()
       verify()
     }
 
-    conf.apples() shouldBe List(-1, -2)
+    Conf.apples() shouldBe List(-1, -2)
   }
 
   test ("handle trailing args in conjunction with --arg=value option style") {
-    val conf = new ScallopConf(Seq("--apples=-1", "basket")) {
+    object Conf extends ScallopConf(Seq("--apples=-1", "basket")) {
       val apples = opt[Int]()
       val stuff = trailArg[String]()
       verify()
     }
 
-    conf.apples() shouldBe (-1)
-    conf.stuff() shouldBe "basket"
+    Conf.apples() shouldBe (-1)
+    Conf.stuff() shouldBe "basket"
   }
 
   test ("accessing unverified builder from default option value resolver") {
@@ -789,15 +795,15 @@ For all other tricks, consult the documentation!
   }
 
   test ("isSupplied on transformed option with guessed option name") {
-    val config = new ScallopConf(Seq("-i", "5")) {
+    object Config extends ScallopConf(Seq("-i", "5")) {
       val index = opt[Int]().map(_-1)
       verify()
     }
-    config.index.isSupplied shouldEqual true
+    Config.index.isSupplied shouldEqual true
   }
 
   test ("isSupplied on transformed option with guessed option name inside validation") {
-    val config = new ScallopConf(Seq("-i", "5", "-l", "10")) {
+    object Config extends ScallopConf(Seq("-i", "5", "-l", "10")) {
       val index = opt[Int]().map(_-1)
       val length = opt[Int]()
       addValidation {
@@ -807,15 +813,15 @@ For all other tricks, consult the documentation!
       }
       verify()
     }
-    config.index.isSupplied shouldEqual true
+    Config.index.isSupplied shouldEqual true
   }
 
   test ("negative number in trailing arguments") {
-    val config = new ScallopConf(Seq("-1234")) {
+    object Config extends ScallopConf(Seq("-1234")) {
       val value = trailArg[Int]()
       verify()
     }
-    config.value() shouldEqual -1234
+    Config.value() shouldEqual -1234
   }
 
 }

--- a/jvm/src/test/scala/DefaultConverterTest.scala
+++ b/jvm/src/test/scala/DefaultConverterTest.scala
@@ -10,7 +10,7 @@ class DurationConverterTest extends AnyFunSuite with UsefulMatchers {
   throwError.value = true
 
   test("convert to Duration") {
-    def getcf(args: Seq[String]) = new ScallopConf(args) {
+    case class getcf(args0: Seq[String]) extends ScallopConf(args0) {
       val foo = opt[Duration]()
       verify()
     }
@@ -29,7 +29,7 @@ class FiniteDurationConverterTest extends AnyFunSuite with UsefulMatchers {
   throwError.value = true
 
   test("convert to Duration") {
-    def getcf(args: Seq[String]) = new ScallopConf(args) {
+    case class getcf(args0: Seq[String]) extends ScallopConf(args0) {
       val foo = opt[FiniteDuration]()
       verify()
     }

--- a/jvm/src/test/scala/HelpTest.scala
+++ b/jvm/src/test/scala/HelpTest.scala
@@ -221,7 +221,7 @@ class HelpTest extends UsefulMatchers with CapturingTest {
         }
         addSubcommand(peach)
 
-        val submarine = new Subcommand("submarine") {()}
+        val submarine = new Subcommand("submarine") {}
         addSubcommand(submarine)
 
         verify()
@@ -485,52 +485,52 @@ class HelpTest extends UsefulMatchers with CapturingTest {
 
   test ("implicit short option name should override help printing") {
     val exits = trapExit {
-      val conf = new ScallopConf(Seq("-h")) {
+      object Conf extends ScallopConf(Seq("-h")) {
         val hard = opt[Boolean]()
         verify()
       }
-      conf.hard() shouldEqual true
+      Conf.hard() shouldEqual true
     }
     exits.size shouldEqual 0
   }
 
   test ("implicit short option name should override version printing") {
     val exits = trapExit {
-      val conf = new ScallopConf(Seq("-v")) {
+      object Conf extends ScallopConf(Seq("-v")) {
         val verbose = opt[Boolean]()
         version("1.0")
         verify()
       }
-      conf.verbose() shouldEqual true
+      Conf.verbose() shouldEqual true
     }
     exits.size shouldEqual 0
   }
 
   test ("implicit short option name in subcommand should override help printing") {
     val exits = trapExit {
-      val config = new ScallopConf(Seq("cmd", "-h")) {
-        val cmd = new Subcommand("cmd") {
+      object Config extends ScallopConf(Seq("cmd", "-h")) {
+        object cmd extends Subcommand("cmd") {
           val hard = opt[Boolean]()
         }
         addSubcommand(cmd)
         verify()
       }
-      config.cmd.hard() shouldEqual true
+      Config.cmd.hard() shouldEqual true
     }
     exits.size shouldEqual 0
   }
 
   test ("implicit short option name in subcommand should override version printing") {
     val exits = trapExit {
-      val config = new ScallopConf(Seq("cmd", "-v")) {
+      object Config extends ScallopConf(Seq("cmd", "-v")) {
         version("Version 1.0")
-        val cmd = new Subcommand("cmd") {
+        object cmd extends Subcommand("cmd") {
           val verbose = opt[Boolean]()
         }
         addSubcommand(cmd)
         verify()
       }
-      config.cmd.verbose() shouldEqual true
+      Config.cmd.verbose() shouldEqual true
     }
     exits.size shouldEqual 0
   }

--- a/jvm/src/test/scala/NumberOptionTest.scala
+++ b/jvm/src/test/scala/NumberOptionTest.scala
@@ -9,19 +9,19 @@ class NumberOptionTest extends AnyFunSuite with Matchers with CapturingTest with
   throwError.value = true
 
   test ("number option") {
-    val conf = new ScallopConf(Seq("-42")) {
+    object Conf extends ScallopConf(Seq("-42")) {
       val answer = number()
       verify()
     }
-    conf.answer() shouldBe 42
+    Conf.answer() shouldBe 42
   }
 
   test ("required number option provided") {
-    val conf = new ScallopConf(Seq("-42")) {
+    object Conf extends ScallopConf(Seq("-42")) {
       val answer = number(required = true)
       verify()
     }
-    conf.answer.toOption shouldBe Some(42)
+    Conf.answer.toOption shouldBe Some(42)
   }
 
   test ("required number option not provided") {
@@ -34,15 +34,15 @@ class NumberOptionTest extends AnyFunSuite with Matchers with CapturingTest with
   }
 
   test ("multiple number options") {
-    val conf = new ScallopConf(Seq("-1", "-2", "-3")) {
+    object Conf extends ScallopConf(Seq("-1", "-2", "-3")) {
       val first = number()
       val second = number()
       val third = number()
       verify()
     }
-    conf.first() shouldBe 1
-    conf.second() shouldBe 2
-    conf.third() shouldBe 3
+    Conf.first() shouldBe 1
+    Conf.second() shouldBe 2
+    Conf.third() shouldBe 3
   }
 
   test ("number option validation success") {

--- a/jvm/src/test/scala/OptionNameGuessing.scala
+++ b/jvm/src/test/scala/OptionNameGuessing.scala
@@ -57,7 +57,7 @@ class OptionNameGuessing extends UsefulMatchers {
 
   test ("guessing in subcommands") {
     object Conf extends ScallopConf(Seq("tree", "--apples", "3")) {
-      val tree = new Subcommand("tree") {
+      object tree extends Subcommand("tree") {
         val apples = opt[Int]()
       }
       addSubcommand(tree)

--- a/jvm/src/test/scala/SubcommandsTest.scala
+++ b/jvm/src/test/scala/SubcommandsTest.scala
@@ -23,7 +23,7 @@ class SubcommandsTest extends UsefulMatchers {
   test ("conf") {
     object Conf extends ScallopConf(Seq("-a", "tree", "-b")) {
       val apples = opt[Boolean]("apples")
-      val tree = new Subcommand("tree") {
+      object tree extends Subcommand("tree") {
         val bananas = opt[Boolean]("bananas")
       }
       addSubcommand(tree)
@@ -41,7 +41,7 @@ class SubcommandsTest extends UsefulMatchers {
   test ("options are not supplied") {
     object Conf extends ScallopConf(Seq()) {
       val apples = opt[Boolean]("apples")
-      val tree = new Subcommand("tree") {
+      object tree extends Subcommand("tree") {
         val bananas = opt[Boolean]("bananas")
       }
       addSubcommand(tree)
@@ -54,12 +54,12 @@ class SubcommandsTest extends UsefulMatchers {
 
   test ("two nested configs") {
     object Conf extends ScallopConf(Seq("palm","-b")) {
-      val tree = new Subcommand("tree") {
+      object tree extends Subcommand("tree") {
         val apples = opt[Boolean]("apples")
       }
       addSubcommand(tree)
 
-      val palm = new Subcommand("palm") {
+      object palm extends Subcommand("palm") {
         val bananas = opt[Boolean]("bananas")
       }
       addSubcommand(palm)
@@ -79,10 +79,10 @@ class SubcommandsTest extends UsefulMatchers {
 
   test ("4-level nested subcommands") {
     object Conf extends ScallopConf(Seq("sub1", "sub2", "sub3", "sub4", "win!")) {
-      val sub1 = new Subcommand("sub1") {
-        val sub2 = new Subcommand("sub2") {
-          val sub3 = new Subcommand("sub3") {
-            val sub4 = new Subcommand("sub4") {
+      object sub1 extends Subcommand("sub1") {
+        object sub2 extends Subcommand("sub2") {
+          object sub3 extends Subcommand("sub3") {
+            object sub4 extends Subcommand("sub4") {
               val opts = trailArg[List[String]]()
             }
             addSubcommand(sub4)
@@ -101,7 +101,7 @@ class SubcommandsTest extends UsefulMatchers {
 
   test ("equal names in two subcommands") {
     object Conf extends ScallopConf(Seq("tree","-a")) {
-      val tree = new Subcommand("tree") {
+      object tree extends Subcommand("tree") {
         val apples = opt[Boolean]("apples")
       }
       addSubcommand(tree)
@@ -118,7 +118,7 @@ class SubcommandsTest extends UsefulMatchers {
 
   test ("codependency, inside subcommand, success") {
     object Conf extends ScallopConf(Seq("tree", "-a", "-b")) {
-      val tree = new Subcommand("tree") {
+      object tree extends Subcommand("tree") {
         val apples = opt[Boolean]("apples")
         val bananas = opt[Boolean]("bananas")
         codependent(apples, bananas)
@@ -149,7 +149,7 @@ class SubcommandsTest extends UsefulMatchers {
   test ("codependency, across confs, success") {
     object Conf extends ScallopConf(Seq("-a", "tree", "-b")) {
       val apples = opt[Boolean]("apples")
-      val tree = new Subcommand("tree") {
+      object tree extends Subcommand("tree") {
         val bananas = opt[Boolean]("bananas")
       }
       addSubcommand(tree)
@@ -166,7 +166,7 @@ class SubcommandsTest extends UsefulMatchers {
     expectException(ValidationFailure("Either all or none of the following options should be supplied, because they are co-dependent: apples, bananas")) {
       new ScallopConf(Seq("-a", "tree")) {
         val apples = opt[Boolean]("apples")
-        val tree = new Subcommand("tree") {
+        object tree extends Subcommand("tree") {
           val bananas = opt[Boolean]("bananas")
         }
         addSubcommand(tree)
@@ -180,7 +180,7 @@ class SubcommandsTest extends UsefulMatchers {
 
   test ("no-option subcommands") {
     object Conf extends ScallopConf(Seq("tree")) {
-      val tree = new Subcommand("tree") {()}
+      val tree = new Subcommand("tree") {}
       addSubcommand(tree)
 
       verify()
@@ -190,7 +190,7 @@ class SubcommandsTest extends UsefulMatchers {
 
   test ("isSupplied, if there are no selected subcommands") {
     object Conf extends ScallopConf(Nil) {
-      val tree = new Subcommand("tree") {
+      object tree extends Subcommand("tree") {
         val apples = opt[Int]("apples")
       }
       addSubcommand(tree)
@@ -207,7 +207,7 @@ class SubcommandsTest extends UsefulMatchers {
       }
       addSubcommand(tree)
 
-      val palm = new Subcommand("palm") {
+      object palm extends Subcommand("palm") {
         val bananas = opt[Int]("bananas")
       }
       addSubcommand(palm)
@@ -219,10 +219,10 @@ class SubcommandsTest extends UsefulMatchers {
 
   test ("subcommand name as parameter to other subcommand") {
     object Conf extends ScallopConf(Seq("help", "tree")) {
-      val tree = new Subcommand("tree") {()}
+      val tree = new Subcommand("tree") {}
       addSubcommand(tree)
 
-      val help = new Subcommand("help")  {
+      object help extends Subcommand("help")  {
         val command = trailArg[String]()
       }
       addSubcommand(help)
@@ -234,7 +234,7 @@ class SubcommandsTest extends UsefulMatchers {
 
   test ("properties on subcommand") {
     object Conf extends ScallopConf(Seq("sub", "-Dkey1=value1")) {
-      val sub = new Subcommand("sub") {
+      object sub extends Subcommand("sub") {
         val properties = props[String]('D')
       }
       addSubcommand(sub)
@@ -245,20 +245,20 @@ class SubcommandsTest extends UsefulMatchers {
   }
 
   test ("subcommand name guessing") {
-    val conf = new ScallopConf(Seq("tree", "--apples", "42")) {
-      val tree = new Subcommand("tree") {
+    object Conf extends ScallopConf(Seq("tree", "--apples", "42")) {
+      object tree extends Subcommand("tree") {
         val apples = opt[Int]()
       }
       addSubcommand(tree)
 
       verify()
     }
-    conf.tree.apples.toOption shouldBe Some(42)
+    Conf.tree.apples.toOption shouldBe Some(42)
   }
 
   test ("isSupplied on subcommand options - true") {
-    val conf = new ScallopConf(Seq("tree", "--apples")) {
-      val tree = new Subcommand("tree") {
+    object Conf extends ScallopConf(Seq("tree", "--apples")) {
+      object tree extends Subcommand("tree") {
         val apples = opt[Boolean]()
       }
       addSubcommand(tree)
@@ -266,12 +266,12 @@ class SubcommandsTest extends UsefulMatchers {
       verify()
     }
 
-    conf.tree.apples.isSupplied shouldBe true
+    Conf.tree.apples.isSupplied shouldBe true
   }
 
   test ("isSupplied on subcommand options - false") {
-    val conf = new ScallopConf(Seq("tree")) {
-      val tree = new Subcommand("tree") {
+    object Conf extends ScallopConf(Seq("tree")) {
+      object tree extends Subcommand("tree") {
         val apples = opt[Boolean]()
       }
       addSubcommand(tree)
@@ -279,12 +279,12 @@ class SubcommandsTest extends UsefulMatchers {
       verify()
     }
 
-    conf.tree.apples.isSupplied shouldBe false
+    Conf.tree.apples.isSupplied shouldBe false
   }
 
   test ("subcommand aliases") {
     object Conf extends ScallopConf(Seq("apple", "-c", "42")) {
-      val fruit = new Subcommand("fruit", "apple", "banana") {
+      object fruit extends Subcommand("fruit", "apple", "banana") {
         val count = opt[Int]()
       }
       addSubcommand(fruit)
@@ -299,7 +299,7 @@ class SubcommandsTest extends UsefulMatchers {
 
   test ("require subcommand to be present - successfull case") {
     object Conf extends ScallopConf(Seq("fruit", "-c", "42")) {
-      val fruit = new Subcommand("fruit") {
+      object fruit extends Subcommand("fruit") {
         val count = opt[Int]()
       }
       addSubcommand(fruit)
@@ -328,8 +328,8 @@ class SubcommandsTest extends UsefulMatchers {
 
   test ("require several nested subcommands to be present - successfull case") {
     object Conf extends ScallopConf(Seq("fruit", "pick", "-c", "42")) {
-      val fruit = new Subcommand("fruit") {
-        val pick = new Subcommand("pick") {
+      object fruit extends Subcommand("fruit") {
+        object pick extends Subcommand("pick") {
           val count = opt[Int]()
         }
         addSubcommand(pick)

--- a/jvm/src/test/scala/ToggleOptionTest.scala
+++ b/jvm/src/test/scala/ToggleOptionTest.scala
@@ -10,11 +10,11 @@ class ToggleOptionTest extends AnyFunSuite with Matchers {
   throwError.value = true
 
   test ("short name") {
-    val conf = new ScallopConf(Seq("-e")) {
+    object Conf extends ScallopConf(Seq("-e")) {
       val answer = toggle(name = "tgl-option", short = 'e', default = Some(false))
       verify()
     }
-    conf.answer() shouldBe true
+    Conf.answer() shouldBe true
   }
 
   test("unknown option") {

--- a/jvm/src/test/scala/TrailingArgumentsParseTest.scala
+++ b/jvm/src/test/scala/TrailingArgumentsParseTest.scala
@@ -9,14 +9,14 @@ class TrailingArgumentsParseTest extends AnyFunSuite with Matchers with UsefulMa
   throwError.value = true
 
   test ("non-required trailing option after flag") {
-    val conf = new ScallopConf(Seq("-a")) {
+    object Conf extends ScallopConf(Seq("-a")) {
       val apple = opt[Boolean]("apple")
       val banana = trailArg[String](required = false)
 
       verify()
     }
-    conf.apple.toOption shouldBe Some(true)
-    conf.banana.toOption shouldBe None
+    Conf.apple.toOption shouldBe Some(true)
+    Conf.banana.toOption shouldBe None
   }
 
   test ("proper error message on trailing file option failure") {

--- a/jvm/src/test/scala/UsefulMatchers.scala
+++ b/jvm/src/test/scala/UsefulMatchers.scala
@@ -1,11 +1,15 @@
 package org.rogach.scallop
 
+import org.scalatest.Assertion
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 trait UsefulMatchers extends AnyFunSuite with Matchers {
+  abstract class GoodEquals[A](val a: A) {
+    def ====[B](b: B): Assertion
+  }
 
-  implicit def toGoodEquals[A](a: A) = new {
+  implicit def toGoodEquals[A](a0: A): GoodEquals[A] = new GoodEquals[A](a0) {
     def ====[B](b: B) = a should equal (b)
   }
 

--- a/jvm/src/test/scala/ValueConverterTest.scala
+++ b/jvm/src/test/scala/ValueConverterTest.scala
@@ -6,7 +6,7 @@ class ValueConverterTest extends AnyFunSuite with UsefulMatchers {
   throwError.value = true
 
   test ("optional value - flatMap way") {
-    def getcf(args: Seq[String]) = new ScallopConf(args) {
+    case class getcf(args0: Seq[String]) extends ScallopConf(args0) {
       val foo = opt[Option[String]]()(stringListConverter.flatMap {
         case Nil => Right(None)
         case v :: Nil => Right(Option(Option(v)))
@@ -33,7 +33,7 @@ class ValueConverterTest extends AnyFunSuite with UsefulMatchers {
     import org.rogach.scallop.exceptions.WrongOptionFormat
 
     def d(s: String) = new SimpleDateFormat("yyyy-MM-dd").parse(s)
-    def getcf(args: Seq[String]) = new ScallopConf(args) {
+    case class getcf(args0: Seq[String]) extends ScallopConf(args0) {
       implicit def dateConverter: ValueConverter[Date] = singleArgConverter[Date](new SimpleDateFormat("yyyyMMdd").parse(_))
 
       val from = opt[Date]("from")
@@ -54,36 +54,36 @@ class ValueConverterTest extends AnyFunSuite with UsefulMatchers {
   }
 
   test("optDefault - no call") {
-    val conf = new ScallopConf() {
+    object Conf extends ScallopConf() {
       val apples = opt[Int]()(optDefault(5))
 
       verify()
     }
-    conf.apples.toOption ==== None
-    conf.apples.isSupplied ==== false
+    Conf.apples.toOption ==== None
+    Conf.apples.isSupplied ==== false
   }
   test("optDefault - empty call") {
-    val conf = new ScallopConf(Seq("-a")) {
+    object Conf extends ScallopConf(Seq("-a")) {
       val apples = opt[Int]()(optDefault(5))
 
       verify()
     }
-    conf.apples.toOption ==== Some(5)
-    conf.apples.isSupplied ==== true
+    Conf.apples.toOption ==== Some(5)
+    Conf.apples.isSupplied ==== true
   }
   test("optDefault - arg provided") {
-    val conf = new ScallopConf(Seq("-a", "7")) {
+    object Conf extends ScallopConf(Seq("-a", "7")) {
       val apples = opt[Int]()(optDefault(5))
 
       verify()
     }
-    conf.apples.toOption ==== Some(7)
-    conf.apples.isSupplied ==== true
+    Conf.apples.toOption ==== Some(7)
+    Conf.apples.isSupplied ==== true
   }
 
   test ("value converter is only called once when option is retrieved multiple times") {
     var callCount = 0
-    val conf = new ScallopConf(Seq("-a", "1")) {
+    object Conf extends ScallopConf(Seq("-a", "1")) {
       val apples = opt[Int]()(singleArgConverter { str =>
         callCount += 1
         str.toInt + 2
@@ -92,8 +92,8 @@ class ValueConverterTest extends AnyFunSuite with UsefulMatchers {
 
       verify()
     }
-    conf.apples.toOption shouldBe Some(3)
-    conf.apples.toOption shouldBe Some(3)
+    Conf.apples.toOption shouldBe Some(3)
+    Conf.apples.toOption shouldBe Some(3)
     callCount shouldBe 1
   }
 

--- a/native/src/main/scala/org.rogach.scallop/package.scala
+++ b/native/src/main/scala/org.rogach.scallop/package.scala
@@ -4,7 +4,7 @@ import java.io.File
 
 package object scallop extends DefaultConverters {
   implicit val fileConverter: ValueConverter[File] =
-    singleArgConverter(new File(_))
+    singleArgConverter(new File(_), PartialFunction.empty)  // Note: important to provide default arg (Dotty)
   implicit val fileListConverter: ValueConverter[List[File]] =
     listArgConverter(new File(_))
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.4.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,10 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.3.1")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.9")
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.2")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.6")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.0.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.3")
 addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.1.1")

--- a/src/main/scala/org.rogach.scallop/CliOptions.scala
+++ b/src/main/scala/org.rogach.scallop/CliOptions.scala
@@ -69,7 +69,7 @@ case class SimpleOption(
   def requiredShortNames = if (noshort) Nil else short.toList
 
   def argLine(sh: List[Char]): String = {
-    (List(sh.map("-" +), List("--" + name)).flatten.mkString(", ") + "  " + converter.argFormat(argName)).trim
+    (List(sh.map("-" + _), List("--" + name)).flatten.mkString(", ") + "  " + converter.argFormat(argName)).trim
   }
   def helpInfo(sh: List[Char]) = List(HelpInfo(
     argLine(sh),
@@ -207,7 +207,7 @@ case class ToggleOption(
 
   def argLine(sh: List[Char]): String = throw new MajorInternalException
   def helpInfo(sh: List[Char]) = List(
-    HelpInfo((sh.map("-" +) ++ List("--" + name) mkString ", "), descrYes, () => None),
+    HelpInfo((sh.map("-" + _) ++ List("--" + name) mkString ", "), descrYes, () => None),
     HelpInfo(("--" + prefix + name), descrNo, () => None)
   )
 }

--- a/src/main/scala/org.rogach.scallop/Scallop.scala
+++ b/src/main/scala/org.rogach.scallop/Scallop.scala
@@ -90,7 +90,7 @@ case class Scallop(
   /** Parse the argument into list of options and their arguments. */
   private def parse(args: CSeq[String]): ParseResult = {
     subbuilders.filter(s => args.contains(s._1)).sortBy(s => args.indexOf(s._1)).headOption match {
-      case Some((name, sub)) => ParseResult(parse(Nil, args.takeWhile(name!=).toList), Some(name), args.dropWhile(name!=).drop(1).toList)
+      case Some((name, sub)) => ParseResult(parse(Nil, args.takeWhile(name != _).toList), Some(name), args.dropWhile(name != _).drop(1).toList)
       case None => ParseResult(parse(Nil, args.toList))
     }
   }
@@ -436,7 +436,7 @@ case class Scallop(
     */
   def findSubbuilder(name: String): Option[Scallop] = {
     if (name.contains('\u0000')) {
-      val (firstSub, rest) = name.span('\u0000'!=)
+      val (firstSub, rest) = name.span('\u0000' != _)
       subbuilders.find(_._1 == firstSub).flatMap(_._2.findSubbuilder(rest.tail))
     } else subbuilders.find(_._1 == name).map(_._2)
   }
@@ -516,7 +516,7 @@ case class Scallop(
         .find(_._1 == subc).map(_._2)
         .filter { subBuilder =>
           subbuilders.filter(_._2 == subBuilder)
-          .exists(_._1 == name.takeWhile('\u0000'!=))
+          .exists(_._1 == name.takeWhile('\u0000' != _))
         }
         .map { subBuilder =>
           subBuilder.args(parsed.subcommandArgs).isSupplied(name.dropWhile('\u0000'!=).drop(1))


### PR DESCRIPTION
- there is inference of structural types / abstract classes with added
  methods, so instead of `val conf = new ScallopConf { ... }`, one
  has to use `object conf extends ScallopConf { ... }`; the same goes
  for `Subcommand` usage. (these are changes in test sources only)
- updated sbt version, plug-ins, such as scala.js to 1.3.1; had to drop 2.10
  support for scala.js
- updated .travis.yaml to test all platforms. ~scala.js test under~
  ~scala 2.12 currently doesn't work (scala.js bug in the test~
  ~interface, it seems)~
- fixed problem with Dotty where singleArgConverter cannot be
  invoked with default arguments from package object, otherwise
  the default argument for handler is broken
- added travis CI status badge to README

prepares for #215