### PR TITLE
Bump dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ language: scala
 
 scala:
   - 2.11.12
-  - 2.12.12
+  - 2.12.13
   - 2.13.4
-  - 3.0.0-M2
+  - 3.0.0-M3
 
 jdk:
   - openjdk8

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
-lazy val scalaVersionsJVM = Seq("3.0.0-M2", "2.13.4", "2.12.12", "2.11.12", "2.10.7")
+lazy val scalaVersionsJVM = Seq("3.0.0-M3", "2.13.4", "2.12.13", "2.11.12", "2.10.7")
 lazy val scalaVersionsSN  = Seq("2.11.12")
-lazy val scalaVersionsJS  = Seq("2.13.4", "2.12.12", "2.11.12")
+lazy val scalaVersionsJS  = Seq("2.13.4", "2.12.13", "2.11.12")
 
 lazy val scalaTestVersion = "3.2.3"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.4
+sbt.version=1.4.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.3.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.4.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.9")
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.6")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.1")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.0.0")


### PR DESCRIPTION
Bump all dependencies, including Scala Native.

Missing work:
- [ ] Bump [scalatest](https://github.com/scalatest/scalatest/pull/1956) once Scala Native 0.4.0 is supported;
- [ ] Rewrite Scala Native test to use Scalatest (Current [test](https://github.com/scallop/scallop/blob/develop/native/src/test/scala/NativeTests.scala) does not work as testing infrastructure has changed, and a [unguessable/random port](https://github.com/scala-native/scala-native/blob/e423109f34a0678582d0955288b3b5d13710d3e2/test-runner/src/main/scala/scala/scalanative/testinterface/NativeRunnerRPC.scala#L20-L28) is expected as the first argument).

Script to tests all configurations:
```
set -e

for SCALA_VERSION in '2.11.12' '2.12.13' '2.13.4' '3.0.0-M3'
do
  sbt "++${SCALA_VERSION}" \
    scallopJVM/test scallopJVM/publishLocal \
    scallopJS/test scallopJS/publishLocal \
    scallopNative/test scallopNative/publishLocal
done

```