### PR TITLE
Add support for Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
-lazy val scalaVersionsJVM = Seq("3.0.0-RC1", "2.13.4", "2.12.13", "2.11.12", "2.10.7")
-lazy val scalaVersionsSN  = Seq("2.13.4", "2.12.13", "2.11.12")
-lazy val scalaVersionsJS  = Seq("2.13.4", "2.12.13", "2.11.12")
+lazy val scalaVersionsJVM = Seq("3.0.0", "2.13.6", "2.12.13", "2.11.12", "2.10.7")
+lazy val scalaVersionsSN  = Seq("2.13.6", "2.12.13", "2.11.12")
+lazy val scalaVersionsJS  = Seq("3.0.0", "2.13.6", "2.12.13", "2.11.12")
 
-lazy val scalaTestVersion = "3.2.6"
+lazy val scalaTestVersion = "3.2.9"
 
 val snapshotVersion = sys.env.get("SNAPSHOT_VERSION")
 
@@ -34,7 +34,7 @@ lazy val commonSettings = Seq(
     "-language:existentials,implicitConversions",
   ),
   scalacOptions ++= {
-    if (isDotty.value) Nil
+    if (scalaVersion.value.startsWith("3.")) Nil
     else Seq("-Xlint")
   },
   unmanagedSourceDirectories in Compile += {
@@ -79,7 +79,7 @@ lazy val commonSettings = Seq(
   publishMavenStyle := true,
   publishArtifact in Test := false,
   scalacOptions in (Compile, doc) ++= {
-    if (isDotty.value) Nil
+    if (scalaVersion.value.startsWith("3.")) Nil
     else Opts.doc.sourceUrl("https://github.com/scallop/scallop/blob/develop/€{FILE_PATH}.scala")
   },
   parallelExecution in Test := false,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.8
+sbt.version=1.5.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,5 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.4.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.5.1")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.0")
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.3")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.0.0")


### PR DESCRIPTION
- Bump scala to [3.0.0](https://www.scala-lang.org/blog/2021/05/14/scala3-is-here.html) (from 3.0.0-RC1) and 2.13.5 (from 2.13.4)
- Bump sbt to [1.5.2](https://github.com/sbt/sbt/releases/tag/v1.5.0)
- Bump scalatest to [3.2.9](https://github.com/scalatest/scalatest/issues/2027)
- Remove `sbt-dotty` as now useless with sbt 1.5.x & fix `isDotty` usage
- Bump Scala.js to [1.5.1](https://www.scala-js.org/news/2020/11/16/announcing-scalajs-1.5.1/)