### PR TITLE
Scala Native 0.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
-lazy val scalaVersionsJVM = Seq("3.3.4", "2.13.15", "2.12.20", "2.11.12", "2.10.7")
+lazy val scalaVersionsJVM = Seq("3.3.4", "3.2.2", "3.1.3", "2.13.15", "2.12.20", "2.11.12", "2.10.7")
 lazy val scalaVersionsSN  = Seq("2.13.15", "2.12.20")
-lazy val scalaVersionsJS  = Seq("3.3.4", "2.13.15", "2.12.20")
+lazy val scalaVersionsJS  = Seq("3.3.4", "3.2.2", "3.1.3", "2.13.15", "2.12.20")
 
 lazy val scalaTestVersion = "3.2.19"
 
@@ -48,7 +48,6 @@ lazy val commonSettings = Seq(
         base / "scala-2.13-"
     }
   },
-  //unmanagedSourceDirectories in Test += baseDirectory.value.getParentFile / "src" / "main",
   licenses := Seq(
     "MIT License" -> url("http://www.opensource.org/licenses/mit-license.php")
   ),

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
-lazy val scalaVersionsJVM = Seq("3.0.0", "2.13.6", "2.12.13", "2.11.12", "2.10.7")
-lazy val scalaVersionsSN  = Seq("2.13.6", "2.12.13", "2.11.12")
-lazy val scalaVersionsJS  = Seq("3.0.0", "2.13.6", "2.12.13", "2.11.12")
+lazy val scalaVersionsJVM = Seq("3.3.4", "2.13.15", "2.12.20", "2.11.12", "2.10.7")
+lazy val scalaVersionsSN  = Seq("2.13.15", "2.12.20")
+lazy val scalaVersionsJS  = Seq("3.3.4", "2.13.15", "2.12.20")
 
-lazy val scalaTestVersion = "3.2.9"
+lazy val scalaTestVersion = "3.2.19"
 
 val snapshotVersion = sys.env.get("SNAPSHOT_VERSION")
 
@@ -48,6 +48,7 @@ lazy val commonSettings = Seq(
         base / "scala-2.13-"
     }
   },
+  //unmanagedSourceDirectories in Test += baseDirectory.value.getParentFile / "src" / "main",
   licenses := Seq(
     "MIT License" -> url("http://www.opensource.org/licenses/mit-license.php")
   ),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.5.1")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.17.0")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.6")
 
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
-addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.0.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.3")
 addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")


### PR DESCRIPTION
Fixes #245 

Scala Native 0.4.0 -> 0.5.6.

As part of fixing the problems with dependencies I have also updated other versions.
- scalajs 1.5.1 -> 1.17.0
- sbt crossproject 1.0.0 -> 1.3.2
- Scala 3.0.0 -> 3.3.4, 2.13.6 -> 2.13.15, 2.12.13 -> 2.12.20
- IMPORTANT: I have dropped the support of Scala 2.11 for Scala Native and Scala JS due to the absence of 2.11 artifacts in their new versions
- Scalatest 3.2.9 -> 3.2.19