### PR TITLE
feat: added option for disabling reading from file or stdin

### DIFF
--- a/js/src/main/scala/org.rogach.scallop/ScallopArgListLoader.scala
+++ b/js/src/main/scala/org.rogach.scallop/ScallopArgListLoader.scala
@@ -3,5 +3,5 @@ package org.rogach.scallop
 import scala.collection.{Seq => CSeq}
 
 trait ScallopArgListLoader {
-  def loadArgList(args: CSeq[String]): CSeq[String] = args
+  def loadArgList(args: CSeq[String], canReadFromFileOrStdIn: Boolean): CSeq[String] = args
 }

--- a/js/src/main/scala/org.rogach.scallop/ScallopConf.scala
+++ b/js/src/main/scala/org.rogach.scallop/ScallopConf.scala
@@ -5,8 +5,9 @@ import scala.collection.{Seq => CSeq}
 /** Base class for CLI parsers. */
 abstract class ScallopConf(
   args: CSeq[String] = Nil,
-  commandNameAndAliases: Seq[String] = Nil
-) extends ScallopConfBase(args, commandNameAndAliases) {
+  commandNameAndAliases: Seq[String] = Nil,
+  canReadFromFileOrStdIn: Boolean = true
+) extends ScallopConfBase(args, commandNameAndAliases, canReadFromFileOrStdIn) {
 
   override protected def optionNameGuessingSupported: Boolean = false
   override protected def performOptionNameGuessing(): Unit = {}

--- a/jvm/src/main/scala/org.rogach.scallop/ScallopArgListLoader.scala
+++ b/jvm/src/main/scala/org.rogach.scallop/ScallopArgListLoader.scala
@@ -8,9 +8,9 @@ import scala.collection.{Seq => CSeq}
 
 trait ScallopArgListLoader {
 
-  def loadArgList(args: CSeq[String]): CSeq[String] = {
+  def loadArgList(args: CSeq[String], canReadFromFileOrStdIn: Boolean): CSeq[String] = {
     args.headOption match {
-      case Some(arg) if arg.startsWith("@") =>
+      case Some(arg) if canReadFromFileOrStdIn && arg.startsWith("@") =>
         val (filename, inputStream) =
           if (arg == "@--") {
             // read options from stdin

--- a/jvm/src/main/scala/org.rogach.scallop/ScallopConf.scala
+++ b/jvm/src/main/scala/org.rogach.scallop/ScallopConf.scala
@@ -6,8 +6,9 @@ import org.rogach.scallop.exceptions.OptionNameGuessingException
 /** Base class for CLI parsers. */
 abstract class ScallopConf(
   args: CSeq[String] = Nil,
-  commandNameAndAliases: Seq[String] = Nil
-) extends ScallopConfBase(args, commandNameAndAliases) {
+  commandNameAndAliases: Seq[String] = Nil,
+  canReadFromFileOrStdIn: Boolean = true
+) extends ScallopConfBase(args, commandNameAndAliases, canReadFromFileOrStdIn) {
 
   // machinery to support option name guessing
   override protected def optionNameGuessingSupported: Boolean = true

--- a/jvm/src/test/scala/OptionsReaderTest.scala
+++ b/jvm/src/test/scala/OptionsReaderTest.scala
@@ -44,6 +44,31 @@ class OptionsReaderTest extends ScallopTestBase {
     Conf.escapedSingleQuote() shouldBe "A'B"
   }
 
+  test ("disabled reading options from stdin") {
+    withInput("-a 3\n-b 5") {
+      object Conf extends ScallopConf(List("-p", "@--", "-b", "5"), canReadFromFileOrStdIn = false) {
+        val pattern = opt[String]("pattern")
+        val bananas = opt[Int]("bananas")
+
+        verify()
+      }
+      Conf.pattern() shouldBe "@--"
+      Conf.bananas() shouldBe 5
+    }
+  }
+
+  test ("disabled reading options from file") {
+    object Conf extends ScallopConf(List("-f", "@src/test/resources/opts.txt", "-b", "5"), canReadFromFileOrStdIn = false) {
+      val filename = opt[String]("filename")
+      val bananas = opt[Int]("bananas")
+
+      verify()
+    }
+    Conf.filename() shouldBe "@src/test/resources/opts.txt"
+    Conf.bananas() shouldBe 5
+  }
+
+
   def assertTok(input: String, output: Seq[String]): Unit = {
     ArgumentTokenizer.tokenize(input) match {
       case Matched(output, remainingInput) if remainingInput.length == 0 =>

--- a/native/src/main/scala/org.rogach.scallop/ScallopArgListLoader.scala
+++ b/native/src/main/scala/org.rogach.scallop/ScallopArgListLoader.scala
@@ -8,9 +8,9 @@ import scala.collection.{Seq => CSeq}
 
 trait ScallopArgListLoader {
 
-  def loadArgList(args: CSeq[String]): CSeq[String] = {
+  def loadArgList(args: CSeq[String], canReadFromFileOrStdIn: Boolean): CSeq[String] = {
     args.headOption match {
-      case Some(arg) if arg.startsWith("@") =>
+      case Some(arg) if canReadFromFileOrStdIn && arg.startsWith("@") =>
         val (filename, inputStream) =
           if (arg == "@--") {
             // read options from stdin

--- a/native/src/main/scala/org.rogach.scallop/ScallopConf.scala
+++ b/native/src/main/scala/org.rogach.scallop/ScallopConf.scala
@@ -3,8 +3,9 @@ package org.rogach.scallop
 /** Base class for CLI parsers. */
 abstract class ScallopConf(
   args: Seq[String] = Nil,
-  commandNameAndAliases: Seq[String] = Nil
-) extends ScallopConfBase(args, commandNameAndAliases) {
+  commandNameAndAliases: Seq[String] = Nil,
+  canReadFromFileOrStdIn: Boolean = true
+) extends ScallopConfBase(args, commandNameAndAliases, canReadFromFileOrStdIn) {
 
   override protected def optionNameGuessingSupported: Boolean = false
   override protected def performOptionNameGuessing(): Unit = {

--- a/src/main/scala/org.rogach.scallop/Scallop.scala
+++ b/src/main/scala/org.rogach.scallop/Scallop.scala
@@ -9,11 +9,21 @@ private[scallop] object Scallop {
   /** Create the new parser with some arguments already inserted.
     *
     * @param args Args to pre-insert.
+    * @param canReadFromFileOrStdIn enables/disables reading from files or stdin when using @ syntax. Enabled by default.
     */
-  def apply(args: CSeq[String]): Scallop = new Scallop(args)
+  def apply(
+             args: CSeq[String],
+             canReadFromFileOrStdIn: Boolean
+           ): Scallop = new Scallop(args, canReadFromFileOrStdIn = canReadFromFileOrStdIn)
+
+  /** Create the default empty parser, fresh as mountain air.
+   *
+   * @param canReadFromFileOrStdIn enables/disables reading from files or stdin when using @ syntax. Enabled by default.
+   * */
+  def apply(canReadFromFileOrStdIn: Boolean): Scallop = apply(Nil, canReadFromFileOrStdIn)
 
   /** Create the default empty parser, fresh as mountain air. */
-  def apply(): Scallop = apply(Nil)
+  def apply(): Scallop = apply(Nil, true)
 
   private[scallop] def builtinHelpOpt =
     SimpleOption(
@@ -59,7 +69,8 @@ case class Scallop(
   appendDefaultToDescription: Boolean = false,
   noshort: Boolean = false,
   helpFormatter: ScallopHelpFormatter = new ScallopHelpFormatter,
-  subbuilders: List[(String, Scallop)] = Nil
+  subbuilders: List[(String, Scallop)] = Nil,
+  canReadFromFileOrStdIn: Boolean
 ) extends ScallopArgListLoader {
 
   var parent: Option[Scallop] = None
@@ -349,7 +360,7 @@ case class Scallop(
   }
 
   /** Result of parsing */
-  private lazy val parsed: ParseResult = parse(loadArgList(args))
+  private lazy val parsed: ParseResult = parse(loadArgList(args, canReadFromFileOrStdIn))
 
   /** Tests whether this string contains option name, not some number. */
   private def isOptionName(s: String) =

--- a/src/main/scala/org.rogach.scallop/ScallopConfBase.scala
+++ b/src/main/scala/org.rogach.scallop/ScallopConfBase.scala
@@ -18,7 +18,8 @@ class Subcommand(commandNameAndAliases: String*) extends ScallopConf(Nil, comman
 /** Contains non-platform-specific functionality of ScallopConf. */
 abstract class ScallopConfBase(
   val args: CSeq[String] = Nil,
-  protected val commandNameAndAliases: Seq[String] = Nil
+  protected val commandNameAndAliases: Seq[String] = Nil,
+  protected val canReadFromFileOrStdIn: Boolean
 ) extends ScallopConfValidations {
 
   /** Pointer to parent ScallopConf */
@@ -52,7 +53,7 @@ abstract class ScallopConfBase(
   }
 
   /** Internal immutable builder for options setup. */
-  var builder = Scallop(args)
+  var builder = Scallop(args, canReadFromFileOrStdIn)
 
   private[scallop] def editBuilder(fn: Scallop => Scallop): Unit = {
     builder = fn(builder)


### PR DESCRIPTION
Fixes:  #249    

I have  added an option `canReadFromFileOrStdIn` to `ScallopConf` and underlying classes. The option disables reading from `@filename` or stdin (in case of `@--`).