### PR TITLE
Make TokenizationResult and StringView from o.r.scallop.tokenize public

### DIFF
--- a/src/main/scala/org.rogach.scallop/tokenize/StringView.scala
+++ b/src/main/scala/org.rogach.scallop/tokenize/StringView.scala
@@ -5,7 +5,7 @@ package org.rogach.scallop.tokenize
   *
   * This is needed because since Java 7 String.substring does a full copy instead of sharing the bytes.
   */
-private[scallop] class StringView(underlying: String, offset: Int) {
+class StringView(underlying: String, offset: Int) {
 
   def substring(beginIndex: Int): StringView = {
     new StringView(underlying, offset + beginIndex)

--- a/src/main/scala/org.rogach.scallop/tokenize/TokenizationResult.scala
+++ b/src/main/scala/org.rogach.scallop/tokenize/TokenizationResult.scala
@@ -1,7 +1,7 @@
 package org.rogach.scallop.tokenize
 
-private[scallop] sealed trait TokenizationResult
+sealed trait TokenizationResult
 
-private[scallop] case class Matched(tokens: Seq[String], rest: StringView) extends TokenizationResult
-private[scallop] case object Failed extends TokenizationResult
-private[scallop] case class EOF(expected: String) extends TokenizationResult
+case class Matched(tokens: Seq[String], rest: StringView) extends TokenizationResult
+case object Failed extends TokenizationResult
+case class EOF(expected: String) extends TokenizationResult


### PR DESCRIPTION
This allows users to use the already public ArgumentTokenizer.tokenize(input) method.

Initially, the method exists to parse "command line" arguments from files or stdin. However, there is another use case: parsing "command line" arguments that are received as a single string, for example, via a line-based protocol over a Socket.

To cater for this use case, ArgumentTokenizer.tokenize() needs to be usable by the user. Then the user can provide the "command line" String into tokenize() and pass the Seq[String] result to ScallopConf.